### PR TITLE
Minimum terraform version should be 1.5.0 to use strcontains function

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.5.0"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"


### PR DESCRIPTION
https://github.com/hashicorp/terraform/releases/tag/v1.5.0 - minimum terraform is 1.5.0 to use strcontains function