### PR TITLE
Added network security group association ids to subnet outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -6,7 +6,7 @@ output "subnets" {
       address_prefixes   = s.address_prefixes
       resource_group     = s.resource_group_name
       virtual_network    = s.virtual_network_name
-      nsg_association_id = try(azurerm_subnet_network_security_group_association.vnet[s.name], null)
+      nsg_association_id = try(azurerm_subnet_network_security_group_association.vnet[s.name].id, null)
     }
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,11 +2,11 @@ output "subnets" {
   description = "Information about the subnets created in the module."
   value = {
     for s in azurerm_subnet.subnet : s.name => {
-      id               = s.id
-      address_prefixes = s.address_prefixes
-      resource_group   = s.resource_group_name
-      virtual_network  = s.virtual_network_name
-      nsg_association  = try(azurerm_subnet_network_security_group_association.vnet[s.name], null)
+      id                 = s.id
+      address_prefixes   = s.address_prefixes
+      resource_group     = s.resource_group_name
+      virtual_network    = s.virtual_network_name
+      nsg_association_id = try(azurerm_subnet_network_security_group_association.vnet[s.name], null)
     }
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,7 +6,7 @@ output "subnets" {
       address_prefixes = s.address_prefixes
       resource_group   = s.resource_group_name
       virtual_network  = s.virtual_network_name
-
+      nsg_association  = try(azurerm_subnet_network_security_group_association.vnet[s.name], null)
     }
   }
 }


### PR DESCRIPTION
## Description

Added the `azurerm_subnet_network_security_group_association` ids to the subnet output, so tis module can be used with module `Azure/terraform-azurerm-avm-res-databricks-workspace`.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [X] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `locals.version.tf.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `locals.version.tf.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `locals.version.tf.json`.
  - [ ] Update to documentation

# Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
