### PR TITLE
inversion between peering and subnet in outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -9,7 +9,7 @@ Information about the peerings created in the module.
 
 Please refer to the peering module documentation for details of the outputs
 DESCRIPTION
-  value       = module.subnet
+  value       = module.peering
 }
 
 output "resource" {
@@ -28,5 +28,5 @@ Information about the peerings created in the module.
 
 Please refer to the subnet module documentation for details of the outputs.
 DESCRIPTION
-  value       = module.peering
+  value       = module.subnet
 }


### PR DESCRIPTION
## Description

Outputs between subnets and peerings are inverted. 

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `locals.version.tf.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `locals.version.tf.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `locals.version.tf.json`.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
