### PR TITLE
bug: peering locks missing

### DIFF
--- a/modules/peering/main.tf
+++ b/modules/peering/main.tf
@@ -45,6 +45,8 @@ resource "azapi_resource" "reverse" {
   name                      = var.reverse_name
   parent_id                 = var.remote_virtual_network.resource_id
   schema_validation_enabled = true
+
+  depends_on = [azapi_resource.this]
 }
 
 resource "azapi_resource" "address_space_peering" {
@@ -112,6 +114,7 @@ resource "azapi_resource" "reverse_address_space_peering" {
   schema_validation_enabled = true
 
   depends_on = [
+    azapi_resource.address_space_peering,
     azapi_update_resource.allow_multiple_peering_links_between_vnets,
     azapi_update_resource.remote_allow_multiple_peering_links_between_vnets
   ]
@@ -174,6 +177,7 @@ resource "azapi_resource" "reverse_subnet_peering" {
   schema_validation_enabled = true
 
   depends_on = [
+    azapi_resource.subnet_peering,
     azapi_update_resource.allow_multiple_peering_links_between_vnets,
     azapi_update_resource.remote_allow_multiple_peering_links_between_vnets
   ]

--- a/modules/peering/main.tf
+++ b/modules/peering/main.tf
@@ -17,7 +17,7 @@ resource "azapi_resource" "this" {
       peerCompleteVnets         = var.peer_complete_vnets
     }
   }
-  locks                     = [var.virtual_network.resource_id]
+  locks                     = [var.virtual_network.resource_id, var.remote_virtual_network.resource_id]
   name                      = var.name
   parent_id                 = var.virtual_network.resource_id
   schema_validation_enabled = true
@@ -41,7 +41,7 @@ resource "azapi_resource" "reverse" {
       peerCompleteVnets         = var.reverse_peer_complete_vnets
     }
   }
-  locks                     = [var.remote_virtual_network.resource_id]
+  locks                     = [var.remote_virtual_network.resource_id, var.virtual_network.resource_id]
   name                      = var.reverse_name
   parent_id                 = var.remote_virtual_network.resource_id
   schema_validation_enabled = true
@@ -71,7 +71,7 @@ resource "azapi_resource" "address_space_peering" {
       }
     }
   }
-  locks                     = [var.virtual_network.resource_id]
+  locks                     = [var.virtual_network.resource_id, var.remote_virtual_network.resource_id]
   name                      = var.name
   parent_id                 = var.virtual_network.resource_id
   schema_validation_enabled = true
@@ -106,7 +106,7 @@ resource "azapi_resource" "reverse_address_space_peering" {
       }
     }
   }
-  locks                     = [var.remote_virtual_network.resource_id]
+  locks                     = [var.remote_virtual_network.resource_id, var.virtual_network.resource_id]
   name                      = var.reverse_name
   parent_id                 = var.remote_virtual_network.resource_id
   schema_validation_enabled = true
@@ -137,7 +137,7 @@ resource "azapi_resource" "subnet_peering" {
       remoteSubnetNames         = [for subnet in var.remote_peered_subnets : subnet.subnet_name]
     }
   }
-  locks                     = [var.virtual_network.resource_id]
+  locks                     = [var.virtual_network.resource_id, var.remote_virtual_network.resource_id]
   name                      = var.name
   parent_id                 = var.virtual_network.resource_id
   schema_validation_enabled = true
@@ -168,7 +168,7 @@ resource "azapi_resource" "reverse_subnet_peering" {
       remoteSubnetNames         = [for subnet in var.reverse_remote_peered_subnets : subnet.subnet_name]
     }
   }
-  locks                     = [var.remote_virtual_network.resource_id]
+  locks                     = [var.remote_virtual_network.resource_id, var.virtual_network.resource_id]
   name                      = var.reverse_name
   parent_id                 = var.remote_virtual_network.resource_id
   schema_validation_enabled = true


### PR DESCRIPTION
## Description

Fix missing locks in the peering submodule. This was causing an issue with hub networking where it was trying to update subnets and peering at the same time and throwing a fit.

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
