### PR TITLE
chore: revert peering lock

### DIFF
--- a/modules/peering/main.tf
+++ b/modules/peering/main.tf
@@ -17,7 +17,7 @@ resource "azapi_resource" "this" {
       peerCompleteVnets         = var.peer_complete_vnets
     }
   }
-  locks                     = [var.virtual_network.resource_id, var.remote_virtual_network.resource_id]
+  locks                     = [var.virtual_network.resource_id]
   name                      = var.name
   parent_id                 = var.virtual_network.resource_id
   schema_validation_enabled = true
@@ -41,7 +41,7 @@ resource "azapi_resource" "reverse" {
       peerCompleteVnets         = var.reverse_peer_complete_vnets
     }
   }
-  locks                     = [var.remote_virtual_network.resource_id, var.virtual_network.resource_id]
+  locks                     = [var.remote_virtual_network.resource_id]
   name                      = var.reverse_name
   parent_id                 = var.remote_virtual_network.resource_id
   schema_validation_enabled = true
@@ -73,7 +73,7 @@ resource "azapi_resource" "address_space_peering" {
       }
     }
   }
-  locks                     = [var.virtual_network.resource_id, var.remote_virtual_network.resource_id]
+  locks                     = [var.virtual_network.resource_id]
   name                      = var.name
   parent_id                 = var.virtual_network.resource_id
   schema_validation_enabled = true
@@ -108,7 +108,7 @@ resource "azapi_resource" "reverse_address_space_peering" {
       }
     }
   }
-  locks                     = [var.remote_virtual_network.resource_id, var.virtual_network.resource_id]
+  locks                     = [var.remote_virtual_network.resource_id]
   name                      = var.reverse_name
   parent_id                 = var.remote_virtual_network.resource_id
   schema_validation_enabled = true
@@ -140,7 +140,7 @@ resource "azapi_resource" "subnet_peering" {
       remoteSubnetNames         = [for subnet in var.remote_peered_subnets : subnet.subnet_name]
     }
   }
-  locks                     = [var.virtual_network.resource_id, var.remote_virtual_network.resource_id]
+  locks                     = [var.virtual_network.resource_id]
   name                      = var.name
   parent_id                 = var.virtual_network.resource_id
   schema_validation_enabled = true
@@ -171,7 +171,7 @@ resource "azapi_resource" "reverse_subnet_peering" {
       remoteSubnetNames         = [for subnet in var.reverse_remote_peered_subnets : subnet.subnet_name]
     }
   }
-  locks                     = [var.remote_virtual_network.resource_id, var.virtual_network.resource_id]
+  locks                     = [var.remote_virtual_network.resource_id]
   name                      = var.reverse_name
   parent_id                 = var.remote_virtual_network.resource_id
   schema_validation_enabled = true


### PR DESCRIPTION
## Description

Revert the peering lock since it is not needed now that the depends_on is there. Also may be causing a problem with the mutex.

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
