### PR TITLE
fix(subnet): idempotency issue with azapi version 2.2

### DIFF
--- a/modules/subnet/main.tf
+++ b/modules/subnet/main.tf
@@ -47,6 +47,12 @@ resource "azapi_resource" "subnet" {
     azapi_update_resource.allow_deletion_of_ip_prefix_from_subnet,
     azapi_update_resource.enable_shared_vnet
   ]
+
+  lifecycle {
+    ignore_changes = [
+      body.properties.ipConfigurations
+    ]
+  }
 }
 
 resource "azurerm_role_assignment" "subnet" {


### PR DESCRIPTION
IP configurations were read in as empty objects for each member of the subnet. This fixes that