### PR TITLE
fix: idempotency bug again...

### DIFF
--- a/examples/with_network_interface/README.md
+++ b/examples/with_network_interface/README.md
@@ -1,7 +1,7 @@
 <!-- BEGIN_TF_DOCS -->
 # Example with network interface
 
-This shows what happens if you associate a NIC with a subnet and tests ofr idempotency.
+This shows what happens if you associate a NIC with a subnet and tests for idempotency.
 
 ```hcl
 terraform {

--- a/examples/with_network_interface/README.md
+++ b/examples/with_network_interface/README.md
@@ -1,0 +1,159 @@
+<!-- BEGIN_TF_DOCS -->
+# Example with network interface
+
+This shows what happens if you associate a NIC with a subnet and tests ofr idempotency.
+
+```hcl
+terraform {
+  required_version = ">= 1.9, < 2.0"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.74"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
+## Section to provide a random Azure region for the resource group
+# This allows us to randomize the region for the resource group.
+module "regions" {
+  source  = "Azure/regions/azurerm"
+  version = "~> 0.3"
+}
+
+# This allows us to randomize the region for the resource group.
+resource "random_integer" "region_index" {
+  max = length(module.regions.regions) - 1
+  min = 0
+}
+## End of section to provide a random Azure region for the resource group
+
+# This ensures we have unique CAF compliant names for our resources.
+module "naming" {
+  source  = "Azure/naming/azurerm"
+  version = "~> 0.3"
+}
+
+# This is required for resource modules
+resource "azurerm_resource_group" "this" {
+  location = module.regions.regions[random_integer.region_index.result].name
+  name     = module.naming.resource_group.name_unique
+}
+
+# Creating a virtual network with a unique name, telemetry settings, and in the specified resource group and location.
+module "vnet" {
+  source              = "../../"
+  name                = module.naming.virtual_network.name
+  enable_telemetry    = true
+  resource_group_name = azurerm_resource_group.this.name
+  location            = azurerm_resource_group.this.location
+
+  subnets = {
+    test = {
+      address_prefixes = ["10.0.0.0/16"]
+      name             = "subnet0"
+    }
+  }
+
+  address_space = ["10.0.0.0/16"]
+}
+
+resource "azurerm_network_interface" "test" {
+  location            = azurerm_resource_group.this.location
+  name                = "nic-${module.naming.virtual_network.name}"
+  resource_group_name = azurerm_resource_group.this.name
+
+  ip_configuration {
+    name                          = "ipconfig0"
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = module.vnet.subnets["test"].resource_id
+  }
+}
+```
+
+<!-- markdownlint-disable MD033 -->
+## Requirements
+
+The following requirements are needed by this module:
+
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
+
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 3.74)
+
+- <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.5)
+
+## Resources
+
+The following resources are used by this module:
+
+- [azurerm_network_interface.test](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface) (resource)
+- [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) (resource)
+- [random_integer.region_index](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) (resource)
+
+<!-- markdownlint-disable MD013 -->
+## Required Inputs
+
+No required inputs.
+
+## Optional Inputs
+
+No optional inputs.
+
+## Outputs
+
+No outputs.
+
+## Modules
+
+The following Modules are called:
+
+### <a name="module_naming"></a> [naming](#module\_naming)
+
+Source: Azure/naming/azurerm
+
+Version: ~> 0.3
+
+### <a name="module_regions"></a> [regions](#module\_regions)
+
+Source: Azure/regions/azurerm
+
+Version: ~> 0.3
+
+### <a name="module_vnet"></a> [vnet](#module\_vnet)
+
+Source: ../../
+
+Version:
+
+## Usage
+
+Ensure you have Terraform installed and the Azure CLI authenticated to your Azure subscription.
+
+Navigate to the directory containing this configuration and run:
+
+```
+terraform init
+terraform plan
+terraform apply
+```
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.
+
+## AVM Versioning Notice
+
+Major version Zero (0.y.z) is for initial development. Anything MAY change at any time. The module SHOULD NOT be considered stable till at least it is major version one (1.0.0) or greater. Changes will always be via new versions being published and no changes will be made to existing published versions. For more details please go to https://semver.org/
+<!-- END_TF_DOCS -->

--- a/examples/with_network_interface/_footer.md
+++ b/examples/with_network_interface/_footer.md
@@ -1,0 +1,20 @@
+## Usage
+
+Ensure you have Terraform installed and the Azure CLI authenticated to your Azure subscription.
+
+Navigate to the directory containing this configuration and run:
+
+```
+terraform init
+terraform plan
+terraform apply
+```
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.
+
+
+## AVM Versioning Notice
+
+Major version Zero (0.y.z) is for initial development. Anything MAY change at any time. The module SHOULD NOT be considered stable till at least it is major version one (1.0.0) or greater. Changes will always be via new versions being published and no changes will be made to existing published versions. For more details please go to https://semver.org/

--- a/examples/with_network_interface/_header.md
+++ b/examples/with_network_interface/_header.md
@@ -1,0 +1,3 @@
+# Example with network interface
+
+This shows what happens if you associate a NIC with a subnet and tests ofr idempotency.

--- a/examples/with_network_interface/_header.md
+++ b/examples/with_network_interface/_header.md
@@ -1,3 +1,3 @@
 # Example with network interface
 
-This shows what happens if you associate a NIC with a subnet and tests ofr idempotency.
+This shows what happens if you associate a NIC with a subnet and tests for idempotency.

--- a/examples/with_network_interface/main.tf
+++ b/examples/with_network_interface/main.tf
@@ -1,0 +1,77 @@
+terraform {
+  required_version = ">= 1.9, < 2.0"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.74"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
+## Section to provide a random Azure region for the resource group
+# This allows us to randomize the region for the resource group.
+module "regions" {
+  source  = "Azure/regions/azurerm"
+  version = "~> 0.3"
+}
+
+# This allows us to randomize the region for the resource group.
+resource "random_integer" "region_index" {
+  max = length(module.regions.regions) - 1
+  min = 0
+}
+## End of section to provide a random Azure region for the resource group
+
+# This ensures we have unique CAF compliant names for our resources.
+module "naming" {
+  source  = "Azure/naming/azurerm"
+  version = "~> 0.3"
+}
+
+# This is required for resource modules
+resource "azurerm_resource_group" "this" {
+  location = module.regions.regions[random_integer.region_index.result].name
+  name     = module.naming.resource_group.name_unique
+}
+
+# Creating a virtual network with a unique name, telemetry settings, and in the specified resource group and location.
+module "vnet" {
+  source              = "../../"
+  name                = module.naming.virtual_network.name
+  enable_telemetry    = true
+  resource_group_name = azurerm_resource_group.this.name
+  location            = azurerm_resource_group.this.location
+
+  subnets = {
+    test = {
+      address_prefixes = ["10.0.0.0/16"]
+      name             = "subnet0"
+    }
+  }
+
+  address_space = ["10.0.0.0/16"]
+}
+
+resource "azurerm_network_interface" "test" {
+  location            = azurerm_resource_group.this.location
+  name                = "nic-${module.naming.virtual_network.name}"
+  resource_group_name = azurerm_resource_group.this.name
+
+  ip_configuration {
+    name                          = "ipconfig0"
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = module.vnet.subnets["test"].resource_id
+  }
+}

--- a/main.virtual.network.tf
+++ b/main.virtual.network.tf
@@ -34,6 +34,12 @@ resource "azapi_resource" "vnet" {
   tags                      = var.tags
 
   depends_on = [azapi_update_resource.allow_drop_unencrypted_vnet]
+
+  lifecycle {
+    ignore_changes = [
+      body.properties.subnets,
+    ]
+  }
 }
 
 resource "azapi_update_resource" "allow_drop_unencrypted_vnet" {

--- a/modules/subnet/main.tf
+++ b/modules/subnet/main.tf
@@ -50,7 +50,8 @@ resource "azapi_resource" "subnet" {
 
   lifecycle {
     ignore_changes = [
-      body.properties.ipConfigurations
+      body.properties.ipConfigurations,
+      body.properties.privateEndpoints
     ]
   }
 }


### PR DESCRIPTION
## Description

The read-only properties strike again.

Had to exclude all of subnets on the parent resource as am unable to use splat expressions

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
