### PR TITLE
fix: restrict modtm version to <= 0.3.2 for compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,21 @@ The following requirements are needed by this module:
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116, < 5)
 
-- <a name="requirement_modtm"></a> [modtm](#requirement\_modtm) (~> 0.3)
+- <a name="requirement_modtm"></a> [modtm](#requirement\_modtm) (~> 0.3, <= 0.3.2)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.5)
+
+## Providers
+
+The following providers are used by this module:
+
+- <a name="provider_azapi"></a> [azapi](#provider\_azapi) (>= 1.13, < 3)
+
+- <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) (>= 3.116, < 5)
+
+- <a name="provider_modtm"></a> [modtm](#provider\_modtm) (~> 0.3, <= 0.3.2)
+
+- <a name="provider_random"></a> [random](#provider\_random) (~> 3.5)
 
 ## Resources
 

--- a/terraform.tf
+++ b/terraform.tf
@@ -11,7 +11,7 @@ terraform {
     }
     modtm = {
       source  = "azure/modtm"
-      version = "~> 0.3"
+      version = "~> 0.3, <= 0.3.2"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ x] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x ] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->

Urgent change, the module modtm update 0.3.4 broke every Azure Verified Module depending on it. They included a required parameter module_source_regex that wasn't there in previous versions

Fixes #202

