### PR TITLE
remove dynamic.enabled_metric since it has been removed in azurerm 4.0

### DIFF
--- a/main.interfaces.tf
+++ b/main.interfaces.tf
@@ -55,11 +55,4 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
       category_group = enabled_log.value
     }
   }
-  dynamic "enabled_metric" {
-    for_each = each.value.metric_categories
-
-    content {
-      category = enabled_metric.value
-    }
-  }
 }


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #43 
Closes #43 
-->

Fixes #43 
Closes #43 

The latest version of the module fails to compile due to the dynamic enabled_metric being removed from resource.azurerm_monitor_diagnostic_setting in azurerm 4.x.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ x ] Azure Verified Module updates:
  - [ x ] Bugfix containing backwards compatible bug fixes
    - [ x ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ x ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [ x ] I'm sure there are no other open Pull Requests for the same update/change
- [ x ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ x ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->

Green checks proof:

./avm:

<img width="1512" height="919" alt="image" src="https://github.com/user-attachments/assets/45ee49a4-5f75-46db-901a-196182e9b068" />