### PR TITLE
fix: Handle addressPrefixes during subnet import (Issue #48)

### DIFF
--- a/avm
+++ b/avm
@@ -48,6 +48,15 @@ if [ -d "${AZURE_CONFIG_DIR}" ]; then
   AZURE_CONFIG_MOUNT="-v ${AZURE_CONFIG_DIR}:/home/runtimeuser/.azure"
 fi
 
+# Check if AVM_TMP_DIR is set, if so mount it to /tmp
+if [ -z "${AVM_TMP_DIR}" ] && [ -n "${RUNNER_TEMP}" ]; then
+  AVM_TMP_DIR="${RUNNER_TEMP}"
+fi
+
+if [ -n "${AVM_TMP_DIR}" ]; then
+  TMP_MOUNT="-v ${AVM_TMP_DIR}:/tmp"
+fi
+
 # If the host Docker socket exists, mount it into the container so the container can talk to the host docker daemon
 if [ -S /var/run/docker.sock ]; then
   DOCKER_SOCK_MOUNT="-v /var/run/docker.sock:/var/run/docker.sock"
@@ -99,6 +108,7 @@ if [ -z "${AVM_IN_CONTAINER}" ]; then
     ${AZURE_CONFIG_MOUNT:-} \
     ${DOCKER_SOCK_MOUNT:-} \
     ${SSL_CERT_MOUNTS:-} \
+    ${TMP_MOUNT:-} \
     -e ARM_CLIENT_ID \
     -e ARM_OIDC_REQUEST_TOKEN \
     -e ARM_OIDC_REQUEST_URL \

--- a/avm
+++ b/avm
@@ -96,6 +96,19 @@ if [ -n "${AVM_PORCH_BASE_URL}" ]; then
   PORCH_BASE_URL_MAKE_ADD="PORCH_BASE_URL=${AVM_PORCH_BASE_URL}"
 fi
 
+# Get the repo specific environment variables from avm.config if it exists
+LOCAL_ENVIRONMENT_VARIABLES=""
+if [ -f "avm.config.json" ]; then
+  declare -A variables
+  eval "$(cat "avm.config.json" | jq -r 'to_entries[] | @sh "variables[\(.key|tostring)]=\(.value|tostring)"')"
+
+  for key in "${!variables[@]}"; do
+    export "$key"="${variables[$key]}"
+    LOCAL_ENVIRONMENT_VARIABLES="${LOCAL_ENVIRONMENT_VARIABLES}-e $key "
+    echo "Set environment variable: $key"="${variables[$key]}"
+  done
+fi
+
 # Check if we are running in a container
 # If we are then just run make directly
 if [ -z "${AVM_IN_CONTAINER}" ]; then
@@ -120,11 +133,13 @@ if [ -z "${AVM_IN_CONTAINER}" ]; then
     -e NO_COLOR \
     -e PORCH_LOG_LEVEL \
     -e TF_IN_AUTOMATION=1 \
+    ${LOCAL_ENVIRONMENT_VARIABLES} \
     --env-file <(env | grep '^TF_VAR_') \
     --env-file <(env | grep '^AVM_') \
     "${CONTAINER_IMAGE}" \
     make \
     TUI="${TUI}" \
+    AVM_PORCH_STDOUT="${AVM_PORCH_STDOUT}" \
     AVM_MAKEFILE_REF="${AVM_MAKEFILE_REF}" \
     "${PORCH_BASE_URL_MAKE_ADD}" \
     AVM_PORCH_REF="${AVM_PORCH_REF}" \

--- a/avm.ps1
+++ b/avm.ps1
@@ -130,6 +130,7 @@ if (-not $env:AVM_IN_CONTAINER) {
     "MPTF_URL",
     "NO_COLOR",
     "PORCH_LOG_LEVEL",
+    "AVM_PORCH_STDOUT",
     "TEST_TYPE",
     "TFLINT_CONFIG_URL"
   )
@@ -154,11 +155,25 @@ if (-not $env:AVM_IN_CONTAINER) {
     $dockerArgs += @("-e", "$($_.Name)=$($_.Value)")
   }
 
+  # Add local environment variables from avm.config.json
+  if (Test-Path "avm.config.json") {
+    $jsonContent = Get-Content "avm.config.json" -Raw | ConvertFrom-Json -AsHashtable
+
+    foreach ($key in $jsonContent.Keys) {
+      [System.Environment]::SetEnvironmentVariable($key, $jsonContent[$key])
+      $dockerArgs += @("-e", "$key")
+    }
+  }
+
   $dockerArgs += $CONTAINER_IMAGE
   $dockerArgs += "make"
 
   if ($TUI) {
     $dockerArgs += "TUI=$TUI"
+  }
+
+  if($env:AVM_PORCH_STDOUT) {
+    $dockerArgs += "AVM_PORCH_STDOUT=$($env:AVM_PORCH_STDOUT)"
   }
 
   $dockerArgs += "MAKEFILE_REF=$MAKEFILE_REF"

--- a/examples/complete/region_selection.tf
+++ b/examples/complete/region_selection.tf
@@ -1,68 +1,16 @@
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
   version = "0.9.0"
+
+  is_recommended = true
 }
 
 # This allows us to randomize the region for the resource group.
 resource "random_integer" "region_index" {
-  max = length(local.working_regions_from_module) - 1
+  max = length(module.regions.regions) - 1
   min = 0
 }
 
 locals {
-  selected_region = local.working_regions_from_module[random_integer.region_index.result]
-  # Regions that allow resource group creation as of 15-Oct-2025
-  working_regions = [
-    "australiacentral",
-    "australiaeast",
-    "australiasoutheast",
-    "brazilsouth",
-    "canadacentral",
-    "canadaeast",
-    "centralindia",
-    "centralus",
-    "eastasia",
-    "eastus2",
-    "eastus",
-    "francecentral",
-    "germanywestcentral",
-    "japaneast",
-    "japanwest",
-    "jioindiawest",
-    "koreacentral",
-    "koreasouth",
-    "northcentralus",
-    "northeurope",
-    "norwayeast",
-    "southafricanorth",
-    "southcentralus",
-    "southindia",
-    "southeastasia",
-    "swedencentral",
-    "switzerlandnorth",
-    "uaenorth",
-    "uksouth",
-    "ukwest",
-    "westcentralus",
-    "westeurope",
-    "westindia",
-    "westus2",
-    "westus3",
-    "westus",
-    "qatarcentral",
-    "israelcentral",
-    "polandcentral",
-    "italynorth",
-    "spaincentral",
-    "mexicocentral",
-    "austriaeast",
-    "chilecentral",
-    "malaysiawest",
-    "newzealandnorth",
-    "indonesiacentral",
-    "australiacentral2"
-  ]
-  working_regions_from_module = [
-    for region in module.regions.regions : region.name if contains(local.working_regions, region.name)
-  ]
+  selected_region = module.regions.regions[random_integer.region_index.result].name
 }

--- a/examples/default/region_selection.tf
+++ b/examples/default/region_selection.tf
@@ -1,68 +1,16 @@
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
   version = "0.9.0"
+
+  is_recommended = true
 }
 
 # This allows us to randomize the region for the resource group.
 resource "random_integer" "region_index" {
-  max = length(local.working_regions_from_module) - 1
+  max = length(module.regions.regions) - 1
   min = 0
 }
 
 locals {
-  selected_region = local.working_regions_from_module[random_integer.region_index.result]
-  # Regions that allow resource group creation as of 15-Oct-2025
-  working_regions = [
-    "australiacentral",
-    "australiaeast",
-    "australiasoutheast",
-    "brazilsouth",
-    "canadacentral",
-    "canadaeast",
-    "centralindia",
-    "centralus",
-    "eastasia",
-    "eastus2",
-    "eastus",
-    "francecentral",
-    "germanywestcentral",
-    "japaneast",
-    "japanwest",
-    "jioindiawest",
-    "koreacentral",
-    "koreasouth",
-    "northcentralus",
-    "northeurope",
-    "norwayeast",
-    "southafricanorth",
-    "southcentralus",
-    "southindia",
-    "southeastasia",
-    "swedencentral",
-    "switzerlandnorth",
-    "uaenorth",
-    "uksouth",
-    "ukwest",
-    "westcentralus",
-    "westeurope",
-    "westindia",
-    "westus2",
-    "westus3",
-    "westus",
-    "qatarcentral",
-    "israelcentral",
-    "polandcentral",
-    "italynorth",
-    "spaincentral",
-    "mexicocentral",
-    "austriaeast",
-    "chilecentral",
-    "malaysiawest",
-    "newzealandnorth",
-    "indonesiacentral",
-    "australiacentral2"
-  ]
-  working_regions_from_module = [
-    for region in module.regions.regions : region.name if contains(local.working_regions, region.name)
-  ]
+  selected_region = module.regions.regions[random_integer.region_index.result].name
 }

--- a/examples/existing_vnet_ipam_subnets/region_selection.tf
+++ b/examples/existing_vnet_ipam_subnets/region_selection.tf
@@ -11,7 +11,7 @@ resource "random_integer" "region_index" {
 
 locals {
   selected_region = local.working_regions_from_module[random_integer.region_index.result]
-  # Regions that allow resource group and avnm ipam creation as of 15-Oct-2025
+  # Regions that support AVNM IPAM as of 15-Oct-2025
   working_regions = [
     "eastus2",
     "westus2",

--- a/examples/existing_vnet_peering/region_selection.tf
+++ b/examples/existing_vnet_peering/region_selection.tf
@@ -1,68 +1,16 @@
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
   version = "0.9.0"
+
+  is_recommended = true
 }
 
 # This allows us to randomize the region for the resource group.
 resource "random_integer" "region_index" {
-  max = length(local.working_regions_from_module) - 1
+  max = length(module.regions.regions) - 1
   min = 0
 }
 
 locals {
-  selected_region = local.working_regions_from_module[random_integer.region_index.result]
-  # Regions that allow resource group creation as of 15-Oct-2025
-  working_regions = [
-    "australiacentral",
-    "australiaeast",
-    "australiasoutheast",
-    "brazilsouth",
-    "canadacentral",
-    "canadaeast",
-    "centralindia",
-    "centralus",
-    "eastasia",
-    "eastus2",
-    "eastus",
-    "francecentral",
-    "germanywestcentral",
-    "japaneast",
-    "japanwest",
-    "jioindiawest",
-    "koreacentral",
-    "koreasouth",
-    "northcentralus",
-    "northeurope",
-    "norwayeast",
-    "southafricanorth",
-    "southcentralus",
-    "southindia",
-    "southeastasia",
-    "swedencentral",
-    "switzerlandnorth",
-    "uaenorth",
-    "uksouth",
-    "ukwest",
-    "westcentralus",
-    "westeurope",
-    "westindia",
-    "westus2",
-    "westus3",
-    "westus",
-    "qatarcentral",
-    "israelcentral",
-    "polandcentral",
-    "italynorth",
-    "spaincentral",
-    "mexicocentral",
-    "austriaeast",
-    "chilecentral",
-    "malaysiawest",
-    "newzealandnorth",
-    "indonesiacentral",
-    "australiacentral2"
-  ]
-  working_regions_from_module = [
-    for region in module.regions.regions : region.name if contains(local.working_regions, region.name)
-  ]
+  selected_region = module.regions.regions[random_integer.region_index.result].name
 }

--- a/examples/existing_vnet_peering_sync_address_space/region_selection.tf
+++ b/examples/existing_vnet_peering_sync_address_space/region_selection.tf
@@ -1,68 +1,16 @@
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
   version = "0.9.0"
+
+  is_recommended = true
 }
 
 # This allows us to randomize the region for the resource group.
 resource "random_integer" "region_index" {
-  max = length(local.working_regions_from_module) - 1
+  max = length(module.regions.regions) - 1
   min = 0
 }
 
 locals {
-  selected_region = local.working_regions_from_module[random_integer.region_index.result]
-  # Regions that allow resource group creation as of 15-Oct-2025
-  working_regions = [
-    "australiacentral",
-    "australiaeast",
-    "australiasoutheast",
-    "brazilsouth",
-    "canadacentral",
-    "canadaeast",
-    "centralindia",
-    "centralus",
-    "eastasia",
-    "eastus2",
-    "eastus",
-    "francecentral",
-    "germanywestcentral",
-    "japaneast",
-    "japanwest",
-    "jioindiawest",
-    "koreacentral",
-    "koreasouth",
-    "northcentralus",
-    "northeurope",
-    "norwayeast",
-    "southafricanorth",
-    "southcentralus",
-    "southindia",
-    "southeastasia",
-    "swedencentral",
-    "switzerlandnorth",
-    "uaenorth",
-    "uksouth",
-    "ukwest",
-    "westcentralus",
-    "westeurope",
-    "westindia",
-    "westus2",
-    "westus3",
-    "westus",
-    "qatarcentral",
-    "israelcentral",
-    "polandcentral",
-    "italynorth",
-    "spaincentral",
-    "mexicocentral",
-    "austriaeast",
-    "chilecentral",
-    "malaysiawest",
-    "newzealandnorth",
-    "indonesiacentral",
-    "australiacentral2"
-  ]
-  working_regions_from_module = [
-    for region in module.regions.regions : region.name if contains(local.working_regions, region.name)
-  ]
+  selected_region = module.regions.regions[random_integer.region_index.result].name
 }

--- a/examples/existing_vnet_subnets/region_selection.tf
+++ b/examples/existing_vnet_subnets/region_selection.tf
@@ -1,68 +1,16 @@
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
   version = "0.9.0"
+
+  is_recommended = true
 }
 
 # This allows us to randomize the region for the resource group.
 resource "random_integer" "region_index" {
-  max = length(local.working_regions_from_module) - 1
+  max = length(module.regions.regions) - 1
   min = 0
 }
 
 locals {
-  selected_region = local.working_regions_from_module[random_integer.region_index.result]
-  # Regions that allow resource group creation as of 15-Oct-2025
-  working_regions = [
-    "australiacentral",
-    "australiaeast",
-    "australiasoutheast",
-    "brazilsouth",
-    "canadacentral",
-    "canadaeast",
-    "centralindia",
-    "centralus",
-    "eastasia",
-    "eastus2",
-    "eastus",
-    "francecentral",
-    "germanywestcentral",
-    "japaneast",
-    "japanwest",
-    "jioindiawest",
-    "koreacentral",
-    "koreasouth",
-    "northcentralus",
-    "northeurope",
-    "norwayeast",
-    "southafricanorth",
-    "southcentralus",
-    "southindia",
-    "southeastasia",
-    "swedencentral",
-    "switzerlandnorth",
-    "uaenorth",
-    "uksouth",
-    "ukwest",
-    "westcentralus",
-    "westeurope",
-    "westindia",
-    "westus2",
-    "westus3",
-    "westus",
-    "qatarcentral",
-    "israelcentral",
-    "polandcentral",
-    "italynorth",
-    "spaincentral",
-    "mexicocentral",
-    "austriaeast",
-    "chilecentral",
-    "malaysiawest",
-    "newzealandnorth",
-    "indonesiacentral",
-    "australiacentral2"
-  ]
-  working_regions_from_module = [
-    for region in module.regions.regions : region.name if contains(local.working_regions, region.name)
-  ]
+  selected_region = module.regions.regions[random_integer.region_index.result].name
 }

--- a/examples/ipam_basic/region_selection.tf
+++ b/examples/ipam_basic/region_selection.tf
@@ -11,7 +11,7 @@ resource "random_integer" "region_index" {
 
 locals {
   selected_region = local.working_regions_from_module[random_integer.region_index.result]
-  # Regions that allow resource group and avnm ipam creation as of 15-Oct-2025
+  # Regions that support AVNM IPAM as of 15-Oct-2025
   working_regions = [
     "eastus2",
     "westus2",

--- a/examples/ipam_vnet_only/region_selection.tf
+++ b/examples/ipam_vnet_only/region_selection.tf
@@ -11,7 +11,7 @@ resource "random_integer" "region_index" {
 
 locals {
   selected_region = local.working_regions_from_module[random_integer.region_index.result]
-  # Regions that allow resource group and avnm ipam creation as of 15-Oct-2025
+  # Regions that support AVNM IPAM as of 15-Oct-2025
   working_regions = [
     "eastus2",
     "westus2",

--- a/examples/legacy_address_prefix/region_selection.tf
+++ b/examples/legacy_address_prefix/region_selection.tf
@@ -1,68 +1,16 @@
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
   version = "0.9.0"
+
+  is_recommended = true
 }
 
 # This allows us to randomize the region for the resource group.
 resource "random_integer" "region_index" {
-  max = length(local.working_regions_from_module) - 1
+  max = length(module.regions.regions) - 1
   min = 0
 }
 
 locals {
-  selected_region = local.working_regions_from_module[random_integer.region_index.result]
-  # Regions that allow resource group creation as of 15-Oct-2025
-  working_regions = [
-    "australiacentral",
-    "australiaeast",
-    "australiasoutheast",
-    "brazilsouth",
-    "canadacentral",
-    "canadaeast",
-    "centralindia",
-    "centralus",
-    "eastasia",
-    "eastus2",
-    "eastus",
-    "francecentral",
-    "germanywestcentral",
-    "japaneast",
-    "japanwest",
-    "jioindiawest",
-    "koreacentral",
-    "koreasouth",
-    "northcentralus",
-    "northeurope",
-    "norwayeast",
-    "southafricanorth",
-    "southcentralus",
-    "southindia",
-    "southeastasia",
-    "swedencentral",
-    "switzerlandnorth",
-    "uaenorth",
-    "uksouth",
-    "ukwest",
-    "westcentralus",
-    "westeurope",
-    "westindia",
-    "westus2",
-    "westus3",
-    "westus",
-    "qatarcentral",
-    "israelcentral",
-    "polandcentral",
-    "italynorth",
-    "spaincentral",
-    "mexicocentral",
-    "austriaeast",
-    "chilecentral",
-    "malaysiawest",
-    "newzealandnorth",
-    "indonesiacentral",
-    "australiacentral2"
-  ]
-  working_regions_from_module = [
-    for region in module.regions.regions : region.name if contains(local.working_regions, region.name)
-  ]
+  selected_region = module.regions.regions[random_integer.region_index.result].name
 }

--- a/examples/new_route/region_selection.tf
+++ b/examples/new_route/region_selection.tf
@@ -1,68 +1,16 @@
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
   version = "0.9.0"
+
+  is_recommended = true
 }
 
 # This allows us to randomize the region for the resource group.
 resource "random_integer" "region_index" {
-  max = length(local.working_regions_from_module) - 1
+  max = length(module.regions.regions) - 1
   min = 0
 }
 
 locals {
-  selected_region = local.working_regions_from_module[random_integer.region_index.result]
-  # Regions that allow resource group creation as of 15-Oct-2025
-  working_regions = [
-    "australiacentral",
-    "australiaeast",
-    "australiasoutheast",
-    "brazilsouth",
-    "canadacentral",
-    "canadaeast",
-    "centralindia",
-    "centralus",
-    "eastasia",
-    "eastus2",
-    "eastus",
-    "francecentral",
-    "germanywestcentral",
-    "japaneast",
-    "japanwest",
-    "jioindiawest",
-    "koreacentral",
-    "koreasouth",
-    "northcentralus",
-    "northeurope",
-    "norwayeast",
-    "southafricanorth",
-    "southcentralus",
-    "southindia",
-    "southeastasia",
-    "swedencentral",
-    "switzerlandnorth",
-    "uaenorth",
-    "uksouth",
-    "ukwest",
-    "westcentralus",
-    "westeurope",
-    "westindia",
-    "westus2",
-    "westus3",
-    "westus",
-    "qatarcentral",
-    "israelcentral",
-    "polandcentral",
-    "italynorth",
-    "spaincentral",
-    "mexicocentral",
-    "austriaeast",
-    "chilecentral",
-    "malaysiawest",
-    "newzealandnorth",
-    "indonesiacentral",
-    "australiacentral2"
-  ]
-  working_regions_from_module = [
-    for region in module.regions.regions : region.name if contains(local.working_regions, region.name)
-  ]
+  selected_region = module.regions.regions[random_integer.region_index.result].name
 }

--- a/examples/new_security_rule/region_selection.tf
+++ b/examples/new_security_rule/region_selection.tf
@@ -1,68 +1,16 @@
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
   version = "0.9.0"
+
+  is_recommended = true
 }
 
 # This allows us to randomize the region for the resource group.
 resource "random_integer" "region_index" {
-  max = length(local.working_regions_from_module) - 1
+  max = length(module.regions.regions) - 1
   min = 0
 }
 
 locals {
-  selected_region = local.working_regions_from_module[random_integer.region_index.result]
-  # Regions that allow resource group creation as of 15-Oct-2025
-  working_regions = [
-    "australiacentral",
-    "australiaeast",
-    "australiasoutheast",
-    "brazilsouth",
-    "canadacentral",
-    "canadaeast",
-    "centralindia",
-    "centralus",
-    "eastasia",
-    "eastus2",
-    "eastus",
-    "francecentral",
-    "germanywestcentral",
-    "japaneast",
-    "japanwest",
-    "jioindiawest",
-    "koreacentral",
-    "koreasouth",
-    "northcentralus",
-    "northeurope",
-    "norwayeast",
-    "southafricanorth",
-    "southcentralus",
-    "southindia",
-    "southeastasia",
-    "swedencentral",
-    "switzerlandnorth",
-    "uaenorth",
-    "uksouth",
-    "ukwest",
-    "westcentralus",
-    "westeurope",
-    "westindia",
-    "westus2",
-    "westus3",
-    "westus",
-    "qatarcentral",
-    "israelcentral",
-    "polandcentral",
-    "italynorth",
-    "spaincentral",
-    "mexicocentral",
-    "austriaeast",
-    "chilecentral",
-    "malaysiawest",
-    "newzealandnorth",
-    "indonesiacentral",
-    "australiacentral2"
-  ]
-  working_regions_from_module = [
-    for region in module.regions.regions : region.name if contains(local.working_regions, region.name)
-  ]
+  selected_region = module.regions.regions[random_integer.region_index.result].name
 }

--- a/examples/peer_only_specified_address_spaces/region_selection.tf
+++ b/examples/peer_only_specified_address_spaces/region_selection.tf
@@ -1,68 +1,16 @@
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
   version = "0.9.0"
+
+  is_recommended = true
 }
 
 # This allows us to randomize the region for the resource group.
 resource "random_integer" "region_index" {
-  max = length(local.working_regions_from_module) - 1
+  max = length(module.regions.regions) - 1
   min = 0
 }
 
 locals {
-  selected_region = local.working_regions_from_module[random_integer.region_index.result]
-  # Regions that allow resource group creation as of 15-Oct-2025
-  working_regions = [
-    "australiacentral",
-    "australiaeast",
-    "australiasoutheast",
-    "brazilsouth",
-    "canadacentral",
-    "canadaeast",
-    "centralindia",
-    "centralus",
-    "eastasia",
-    "eastus2",
-    "eastus",
-    "francecentral",
-    "germanywestcentral",
-    "japaneast",
-    "japanwest",
-    "jioindiawest",
-    "koreacentral",
-    "koreasouth",
-    "northcentralus",
-    "northeurope",
-    "norwayeast",
-    "southafricanorth",
-    "southcentralus",
-    "southindia",
-    "southeastasia",
-    "swedencentral",
-    "switzerlandnorth",
-    "uaenorth",
-    "uksouth",
-    "ukwest",
-    "westcentralus",
-    "westeurope",
-    "westindia",
-    "westus2",
-    "westus3",
-    "westus",
-    "qatarcentral",
-    "israelcentral",
-    "polandcentral",
-    "italynorth",
-    "spaincentral",
-    "mexicocentral",
-    "austriaeast",
-    "chilecentral",
-    "malaysiawest",
-    "newzealandnorth",
-    "indonesiacentral",
-    "australiacentral2"
-  ]
-  working_regions_from_module = [
-    for region in module.regions.regions : region.name if contains(local.working_regions, region.name)
-  ]
+  selected_region = module.regions.regions[random_integer.region_index.result].name
 }

--- a/examples/peer_only_specified_subnets/README.md
+++ b/examples/peer_only_specified_subnets/README.md
@@ -9,6 +9,10 @@ terraform {
   required_version = ">= 1.9, < 2.0"
 
   required_providers {
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 2.0"
+    }
     azurerm = {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
@@ -148,6 +152,8 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
+
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.5)
@@ -156,7 +162,7 @@ The following requirements are needed by this module:
 
 The following resources are used by this module:
 
-- [azapi_update_resource.allow_multiple_peering_links_between_vnets](https://registry.terraform.io/providers/hashicorp/azapi/latest/docs/resources/update_resource) (resource)
+- [azapi_update_resource.allow_multiple_peering_links_between_vnets](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/update_resource) (resource)
 - [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) (resource)
 - [random_integer.region_index](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) (resource)
 - [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) (data source)

--- a/examples/peer_only_specified_subnets/README.md
+++ b/examples/peer_only_specified_subnets/README.md
@@ -134,6 +134,10 @@ module "vnet2" {
       address_prefixes = ["10.2.5.0/24", "10.2.6.0/24"]
     }
   }
+
+  depends_on = [
+    azapi_update_resource.allow_multiple_peering_links_between_vnets
+  ]
 }
 ```
 
@@ -152,8 +156,10 @@ The following requirements are needed by this module:
 
 The following resources are used by this module:
 
+- [azapi_update_resource.allow_multiple_peering_links_between_vnets](https://registry.terraform.io/providers/hashicorp/azapi/latest/docs/resources/update_resource) (resource)
 - [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) (resource)
 - [random_integer.region_index](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) (resource)
+- [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) (data source)
 
 <!-- markdownlint-disable MD013 -->
 ## Required Inputs

--- a/examples/peer_only_specified_subnets/main.tf
+++ b/examples/peer_only_specified_subnets/main.tf
@@ -127,4 +127,8 @@ module "vnet2" {
       address_prefixes = ["10.2.5.0/24", "10.2.6.0/24"]
     }
   }
+
+  depends_on = [
+    azapi_update_resource.allow_multiple_peering_links_between_vnets
+  ]
 }

--- a/examples/peer_only_specified_subnets/main.tf
+++ b/examples/peer_only_specified_subnets/main.tf
@@ -2,6 +2,10 @@ terraform {
   required_version = ">= 1.9, < 2.0"
 
   required_providers {
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 2.0"
+    }
     azurerm = {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"

--- a/examples/peer_only_specified_subnets/prerequisites.tf
+++ b/examples/peer_only_specified_subnets/prerequisites.tf
@@ -1,0 +1,14 @@
+# This file contains prerequisite resources that must be registered before deploying the main example.
+# These feature registrations are required at the subscription level.
+
+# Register the feature to allow multiple peering links between VNets
+# This is required for subnet-level peering scenarios
+resource "azapi_update_resource" "allow_multiple_peering_links_between_vnets" {
+  resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.Features/featureProviders/Microsoft.Network/subscriptionFeatureRegistrations/AllowMultiplePeeringLinksBetweenVnets"
+  type        = "Microsoft.Features/featureProviders/subscriptionFeatureRegistrations@2021-07-01"
+  body = {
+    properties = {}
+  }
+}
+
+data "azurerm_client_config" "current" {}

--- a/examples/peer_only_specified_subnets/region_selection.tf
+++ b/examples/peer_only_specified_subnets/region_selection.tf
@@ -1,68 +1,16 @@
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
   version = "0.9.0"
+
+  is_recommended = true
 }
 
 # This allows us to randomize the region for the resource group.
 resource "random_integer" "region_index" {
-  max = length(local.working_regions_from_module) - 1
+  max = length(module.regions.regions) - 1
   min = 0
 }
 
 locals {
-  selected_region = local.working_regions_from_module[random_integer.region_index.result]
-  # Regions that allow resource group creation as of 15-Oct-2025
-  working_regions = [
-    "australiacentral",
-    "australiaeast",
-    "australiasoutheast",
-    "brazilsouth",
-    "canadacentral",
-    "canadaeast",
-    "centralindia",
-    "centralus",
-    "eastasia",
-    "eastus2",
-    "eastus",
-    "francecentral",
-    "germanywestcentral",
-    "japaneast",
-    "japanwest",
-    "jioindiawest",
-    "koreacentral",
-    "koreasouth",
-    "northcentralus",
-    "northeurope",
-    "norwayeast",
-    "southafricanorth",
-    "southcentralus",
-    "southindia",
-    "southeastasia",
-    "swedencentral",
-    "switzerlandnorth",
-    "uaenorth",
-    "uksouth",
-    "ukwest",
-    "westcentralus",
-    "westeurope",
-    "westindia",
-    "westus2",
-    "westus3",
-    "westus",
-    "qatarcentral",
-    "israelcentral",
-    "polandcentral",
-    "italynorth",
-    "spaincentral",
-    "mexicocentral",
-    "austriaeast",
-    "chilecentral",
-    "malaysiawest",
-    "newzealandnorth",
-    "indonesiacentral",
-    "australiacentral2"
-  ]
-  working_regions_from_module = [
-    for region in module.regions.regions : region.name if contains(local.working_regions, region.name)
-  ]
+  selected_region = module.regions.regions[random_integer.region_index.result].name
 }

--- a/examples/service_endpoints_with_locations/region_selection.tf
+++ b/examples/service_endpoints_with_locations/region_selection.tf
@@ -8,67 +8,10 @@ module "regions" {
 
 # This allows us to randomize the region for the resource group.
 resource "random_integer" "region_index" {
-  max = length(local.working_regions_from_module) - 1
+  max = length(module.regions.regions) - 1
   min = 0
 }
 
 locals {
-  selected_region = local.working_regions_from_module[random_integer.region_index.result]
-  # Regions that allow resource group creation as of 15-Oct-2025
-  working_regions = [
-    "australiacentral",
-    "australiaeast",
-    "australiasoutheast",
-    "brazilsouth",
-    "canadacentral",
-    "canadaeast",
-    "centralindia",
-    "centralus",
-    "eastasia",
-    "eastus2",
-    "eastus",
-    "francecentral",
-    "germanywestcentral",
-    "japaneast",
-    "japanwest",
-    "jioindiawest",
-    "koreacentral",
-    "koreasouth",
-    "northcentralus",
-    "northeurope",
-    "norwayeast",
-    "southafricanorth",
-    "southcentralus",
-    "southindia",
-    "southeastasia",
-    "swedencentral",
-    "switzerlandnorth",
-    "uaenorth",
-    "uksouth",
-    "ukwest",
-    "westcentralus",
-    "westeurope",
-    "westindia",
-    "westus2",
-    "westus3",
-    "westus",
-    "qatarcentral",
-    "israelcentral",
-    "polandcentral",
-    "italynorth",
-    "spaincentral",
-    "mexicocentral",
-    "austriaeast",
-    "chilecentral",
-    "malaysiawest",
-    "newzealandnorth",
-    "indonesiacentral",
-    "australiacentral2"
-  ]
-  working_regions_from_module = [
-    for region in module.regions.regions : {
-      name               = region.name
-      paired_region_name = region.paired_region_name
-    } if contains(local.working_regions, region.name)
-  ]
+  selected_region = module.regions.regions[random_integer.region_index.result]
 }

--- a/examples/with_network_interface/region_selection.tf
+++ b/examples/with_network_interface/region_selection.tf
@@ -1,68 +1,16 @@
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
   version = "0.9.0"
+
+  is_recommended = true
 }
 
 # This allows us to randomize the region for the resource group.
 resource "random_integer" "region_index" {
-  max = length(local.working_regions_from_module) - 1
+  max = length(module.regions.regions) - 1
   min = 0
 }
 
 locals {
-  selected_region = local.working_regions_from_module[random_integer.region_index.result]
-  # Regions that allow resource group creation as of 15-Oct-2025
-  working_regions = [
-    "australiacentral",
-    "australiaeast",
-    "australiasoutheast",
-    "brazilsouth",
-    "canadacentral",
-    "canadaeast",
-    "centralindia",
-    "centralus",
-    "eastasia",
-    "eastus2",
-    "eastus",
-    "francecentral",
-    "germanywestcentral",
-    "japaneast",
-    "japanwest",
-    "jioindiawest",
-    "koreacentral",
-    "koreasouth",
-    "northcentralus",
-    "northeurope",
-    "norwayeast",
-    "southafricanorth",
-    "southcentralus",
-    "southindia",
-    "southeastasia",
-    "swedencentral",
-    "switzerlandnorth",
-    "uaenorth",
-    "uksouth",
-    "ukwest",
-    "westcentralus",
-    "westeurope",
-    "westindia",
-    "westus2",
-    "westus3",
-    "westus",
-    "qatarcentral",
-    "israelcentral",
-    "polandcentral",
-    "italynorth",
-    "spaincentral",
-    "mexicocentral",
-    "austriaeast",
-    "chilecentral",
-    "malaysiawest",
-    "newzealandnorth",
-    "indonesiacentral",
-    "australiacentral2"
-  ]
-  working_regions_from_module = [
-    for region in module.regions.regions : region.name if contains(local.working_regions, region.name)
-  ]
+  selected_region = module.regions.regions[random_integer.region_index.result].name
 }

--- a/modules/subnet/outputs.tf
+++ b/modules/subnet/outputs.tf
@@ -1,6 +1,16 @@
 output "address_prefixes" {
   description = "The address prefixes of the subnet. For IPAM subnets, this shows the dynamically allocated ranges."
-  value       = local.ipam_enabled ? azapi_resource.subnet_ipam[0].output.properties.addressPrefixes : try(azapi_resource.subnet[0].output.properties.addressPrefixes, [azapi_resource.subnet[0].output.properties.addressPrefix])
+  value = local.ipam_enabled ? azapi_resource.subnet_ipam[0].output.properties.addressPrefixes : (
+    # Try to get from output.properties first (normal operation)
+    try(azapi_resource.subnet[0].output.properties.addressPrefixes, null) != null ?
+    azapi_resource.subnet[0].output.properties.addressPrefixes :
+    try([azapi_resource.subnet[0].output.properties.addressPrefix], null) != null ?
+    [azapi_resource.subnet[0].output.properties.addressPrefix] :
+    # Fallback to body for import scenarios (when output.properties doesn't contain address info)
+    try(azapi_resource.subnet[0].body.properties.addressPrefixes, null) != null ?
+    azapi_resource.subnet[0].body.properties.addressPrefixes :
+    [azapi_resource.subnet[0].body.properties.addressPrefix]
+  )
 }
 
 output "application_gateway_ip_configuration_resource_id" {

--- a/modules/subnet/outputs.tf
+++ b/modules/subnet/outputs.tf
@@ -1,14 +1,9 @@
 output "address_prefixes" {
   description = "The address prefixes of the subnet. For IPAM subnets, this shows the dynamically allocated ranges."
-  value = local.ipam_enabled ? azapi_resource.subnet_ipam[0].output.properties.addressPrefixes : (
-    # Try to get from output.properties first (normal operation)
-    try(azapi_resource.subnet[0].output.properties.addressPrefixes, null) != null ?
-    azapi_resource.subnet[0].output.properties.addressPrefixes :
-    try([azapi_resource.subnet[0].output.properties.addressPrefix], null) != null ?
-    [azapi_resource.subnet[0].output.properties.addressPrefix] :
-    # Fallback to body for import scenarios (when output.properties doesn't contain address info)
-    try(azapi_resource.subnet[0].body.properties.addressPrefixes, null) != null ?
-    azapi_resource.subnet[0].body.properties.addressPrefixes :
+  value = local.ipam_enabled ? azapi_resource.subnet_ipam[0].output.properties.addressPrefixes : try(
+    azapi_resource.subnet[0].output.properties.addressPrefixes,
+    [azapi_resource.subnet[0].output.properties.addressPrefix],
+    azapi_resource.subnet[0].body.properties.addressPrefixes,
     [azapi_resource.subnet[0].body.properties.addressPrefix]
   )
 }


### PR DESCRIPTION
## Description

This PR fixes the subnet import issue where `terraform import` would fail with "Unsupported attribute: addressPrefixes" error.

**Root Cause:** During import operations, `azapi_resource.subnet[0].output.properties` only contains `provisioningState` and doesn't include address prefix information. The module's outputs.tf was only checking `output.properties`, causing the error.

**Solution:** Added a three-tier fallback logic in `modules/subnet/outputs.tf`:
1. Try `output.properties.addressPrefixes` (normal operation)
2. Try `output.properties.addressPrefix` (single prefix format)
3. Fallback to `body.properties.addressPrefixes` (import scenario)
4. Final fallback to `body.properties.addressPrefix`

This ensures address prefixes are accessible during import while maintaining full backwards compatibility with existing deployments.

**Testing:** Verified both import scenarios and normal subnet creation work without regressions.

Fixes #48

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #48" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all pre-commit checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
