### PR TITLE
 feat(subnet): allow multiple ipam_pools entries per subnet

### DIFF
--- a/modules/subnet/README.md
+++ b/modules/subnet/README.md
@@ -235,7 +235,9 @@ Description: (Optional) A list of IPAM pools to allocate subnet address space fr
 - `pool_id` - (Required) The ID of the IPAM pool to allocate from.
 - `prefix_length` - (Required) The prefix length for the subnet allocation (e.g., 24 for a /24 subnet).
 
-Note: Only one IPAM pool allocation per subnet is currently supported. When using IPAM pools, do not specify `address_prefix` or `address_prefixes`.
+Multiple entries are supported and are passed through to the Azure API as separate `ipamPoolPrefixAllocations`. The platform combines the allocated ranges into the resulting `addressPrefixes` on the subnet. Multiple entries referencing the same `pool_id` are allowed; the IPAM service treats them as independent allocations against that pool.
+
+When using IPAM pools, do not specify `address_prefix` or `address_prefixes`.
 
 Type:
 

--- a/modules/subnet/variables.tf
+++ b/modules/subnet/variables.tf
@@ -92,12 +92,14 @@ variable "ipam_pools" {
 - `pool_id` - (Required) The ID of the IPAM pool to allocate from.
 - `prefix_length` - (Required) The prefix length for the subnet allocation (e.g., 24 for a /24 subnet).
 
-Note: Only one IPAM pool allocation per subnet is currently supported. When using IPAM pools, do not specify `address_prefix` or `address_prefixes`.
+Multiple entries are supported and are passed through to the Azure API as separate `ipamPoolPrefixAllocations`. The platform combines the allocated ranges into the resulting `addressPrefixes` on the subnet. Multiple entries referencing the same `pool_id` are allowed; the IPAM service treats them as independent allocations against that pool.
+
+When using IPAM pools, do not specify `address_prefix` or `address_prefixes`.
 DESCRIPTION
 
   validation {
-    condition     = var.ipam_pools == null ? true : length(var.ipam_pools) == 1
-    error_message = "Only one IPAM pool allocation per subnet is supported."
+    condition     = var.ipam_pools == null ? true : length(var.ipam_pools) >= 1
+    error_message = "When ipam_pools is set it must contain at least one allocation entry."
   }
   validation {
     condition     = var.ipam_pools == null ? true : alltrue([for pool in var.ipam_pools : pool.prefix_length >= 16 && pool.prefix_length <= 30])


### PR DESCRIPTION
## Description
 
 Drops the `length(var.ipam_pools) == 1` validation on the subnet submodule. The underlying ARM resource (`ipamPoolPrefixAllocations`) is already a list and the module already iterates over it correctly; the validation was the only thing blocking multi-entry usage.
 
 **Use case:** consumers who need to compose a subnet's address space from multiple discrete allocations against the same (or different) IPAM pools — e.g., a primary `/25` plus a second `/28` carve-out from the same pool, without forcing the operator to inflate the primary allocation.
 
 **Backwards compatibility:** non-breaking. Existing single-entry configurations continue to validate and behave identically.
 
 **E2E validation:** two entries against pool `pool.v1.validation` (`number_of_ip_addresses = 64` and `16`) on the same subnet in applied successfully, idempotent on re-plan.
 
 ## Type of Change
 
 - [ ] Non-module change (e.g. CI/CD, documentation, etc.)
 - [x] Azure Verified Module updates:
   - [ ] Bugfix containing backwards compatible bug fixes
     - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
     - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
   - [x] Feature update backwards compatible feature updates.
   - [ ] Breaking changes.
   - [ ] Update to documentation
 
 # Checklist
 
 - [x] I'm sure there are no other open Pull Requests for the same update/change
 - [x] My corresponding pipelines / checks run clean and green without any errors or warnings
 - [x] I did run all [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks