### PR TITLE
fix: Support multiple IPAM Pools

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,9 @@ Default: `null`
 
 ### <a name="input_ipam_pools"></a> [ipam\_pools](#input\_ipam\_pools)
 
-Description: (Optional) Specifies the IPAM settings for requesting an address\_space from an IP Pool. Only one IPv4 and one IPv6 pool can be specified.
+Description: (Optional) Specifies the IPAM settings for requesting an address\_space from an IP Pool.
+
+A virtual network supports a maximum of two IPv4 prefix allocations and two IPv6 prefix allocations. When more than one IPv4 (or more than one IPv6) allocation is supplied, every allocation of that IP family must reference the same IPAM pool `id`.
 
 - `id`: The ID of the IPAM pool.
 - `prefix_length`: The length of the /XX CIDR range to request. for example 24 for a /24. Prefix length must be between 2 and 29 for IPv4 and 48 and 64 for IPv6.

--- a/examples/ipam_basic/README.md
+++ b/examples/ipam_basic/README.md
@@ -143,10 +143,16 @@ module "vnet_retry_test" {
   parent_id        = azurerm_resource_group.this.id
   enable_telemetry = true
   # VNet gets address space from IPAM pool
-  ipam_pools = [{
-    id            = azapi_resource.ipam_pool.id
-    prefix_length = 24 # /24 VNet (256 IP addresses)
-  }]
+  ipam_pools = [
+    {
+      id            = azapi_resource.ipam_pool.id
+      prefix_length = 24 # /24 VNet (256 IP addresses)
+    },
+    {
+      id            = azapi_resource.ipam_pool.id
+      prefix_length = 24 # /24 VNet (256 IP addresses)
+    }
+  ]
   name = "${module.naming.virtual_network.name_unique}-retry-test"
   # Multiple IPAM subnets - this should test the retry logic
   subnets = {

--- a/examples/ipam_basic/main.tf
+++ b/examples/ipam_basic/main.tf
@@ -90,10 +90,16 @@ module "vnet_retry_test" {
   parent_id        = azurerm_resource_group.this.id
   enable_telemetry = true
   # VNet gets address space from IPAM pool
-  ipam_pools = [{
-    id            = azapi_resource.ipam_pool.id
-    prefix_length = 24 # /24 VNet (256 IP addresses)
-  }]
+  ipam_pools = [
+    {
+      id            = azapi_resource.ipam_pool.id
+      prefix_length = 24 # /24 VNet (256 IP addresses)
+    },
+    {
+      id            = azapi_resource.ipam_pool.id
+      prefix_length = 24 # /24 VNet (256 IP addresses)
+    }
+  ]
   name = "${module.naming.virtual_network.name_unique}-retry-test"
   # Multiple IPAM subnets - this should test the retry logic
   subnets = {

--- a/variables.tf
+++ b/variables.tf
@@ -185,7 +185,9 @@ variable "ipam_pools" {
   }))
   default     = null
   description = <<DESCRIPTION
-(Optional) Specifies the IPAM settings for requesting an address_space from an IP Pool. Only one IPv4 and one IPv6 pool can be specified.
+(Optional) Specifies the IPAM settings for requesting an address_space from an IP Pool.
+
+A virtual network supports a maximum of two IPv4 prefix allocations and two IPv6 prefix allocations. When more than one IPv4 (or more than one IPv6) allocation is supplied, every allocation of that IP family must reference the same IPAM pool `id`.
 
 - `id`: The ID of the IPAM pool.
 - `prefix_length`: The length of the /XX CIDR range to request. for example 24 for a /24. Prefix length must be between 2 and 29 for IPv4 and 48 and 64 for IPv6.
@@ -204,22 +206,32 @@ DESCRIPTION
     error_message = "Prefix length must be between 2 and 29 for IPv4 and 48 and 64 for IPv6."
   }
   validation {
-    condition = alltrue([
-      for ipam_pool in var.ipam_pools != null ? var.ipam_pools : [] : length(ipam_pool) >= 1 && length(ipam_pool) <= 2
-    ]) || var.ipam_pools == null
-    error_message = "Only one or two IPAM pools can be specified."
+    condition     = var.ipam_pools == null ? true : length(var.ipam_pools) >= 1 && length(var.ipam_pools) <= 4
+    error_message = "Between one and four IPAM pool allocations can be specified (a maximum of two IPv4 and two IPv6 prefix allocations per virtual network)."
   }
   validation {
-    condition = length([
-      for ipam_pool in var.ipam_pools != null ? var.ipam_pools : [] : ipam_pool if ipam_pool.prefix_length == 64
-    ]) <= 1 || var.ipam_pools == null
-    error_message = "Only one IPv6 pool can be specified."
+    condition = var.ipam_pools == null ? true : length([
+      for ipam_pool in var.ipam_pools : ipam_pool if ipam_pool.prefix_length >= 48 && ipam_pool.prefix_length <= 64
+    ]) <= 2
+    error_message = "A maximum of two IPv6 prefix allocations can be specified per virtual network."
   }
   validation {
-    condition = length([
-      for ipam_pool in var.ipam_pools != null ? var.ipam_pools : [] : ipam_pool if ipam_pool.prefix_length >= 2 && ipam_pool.prefix_length <= 29
-    ]) <= 1 || var.ipam_pools == null
-    error_message = "Only one IPv4 pool can be specified."
+    condition = var.ipam_pools == null ? true : length([
+      for ipam_pool in var.ipam_pools : ipam_pool if ipam_pool.prefix_length >= 2 && ipam_pool.prefix_length <= 29
+    ]) <= 2
+    error_message = "A maximum of two IPv4 prefix allocations can be specified per virtual network."
+  }
+  validation {
+    condition = var.ipam_pools == null ? true : length(distinct([
+      for ipam_pool in var.ipam_pools : ipam_pool.id if ipam_pool.prefix_length >= 2 && ipam_pool.prefix_length <= 29
+    ])) <= 1
+    error_message = "When a virtual network contains multiple IPv4 allocations, all allocations must reference the same IPv4 IPAM pool `id`."
+  }
+  validation {
+    condition = var.ipam_pools == null ? true : length(distinct([
+      for ipam_pool in var.ipam_pools : ipam_pool.id if ipam_pool.prefix_length >= 48 && ipam_pool.prefix_length <= 64
+    ])) <= 1
+    error_message = "When a virtual network contains multiple IPv6 allocations, all allocations must reference the same IPv6 IPAM pool `id`."
   }
 }
 


### PR DESCRIPTION
## Description

Customer reported issues when trying to deploy with multiple IPAM Pools. Portal allows this but our AVM validation rules prevented this.

Also added some additional validation to ensure if callers are supplying multiple IPAM Prefixes, they have to be from the same IPAM Pools as per portal validation:

<img width="996" height="814" alt="image" src="https://github.com/user-attachments/assets/41aa0ce6-3d2e-4ef5-87bb-b7d1a7dca122" />

<img width="945" height="667" alt="image" src="https://github.com/user-attachments/assets/0d6bd176-2dd7-474e-a7c8-1fdc6f0d269f" />


## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [X] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [X] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
