### PR TITLE
Bundle IPAM passthrough + validation fixes (#65, #67, #69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,14 +368,16 @@ Default: `null`
 Description: (Optional) Specifies the IPAM settings for requesting an address\_space from an IP Pool. Only one IPv4 and one IPv6 pool can be specified.
 
 - `id`: The ID of the IPAM pool.
-- `prefix_length`: The length of the /XX CIDR range to request. for example 24 for a /24. Prefix length must be between 2 and 29 for IPv4 and 48 and 64 for IPv6.
+- `number_of_ip_addresses`: (Optional) The number of IP addresses to request from the IPAM pool. If not specified, it will be calculated based on the `prefix_length`.
+- `prefix_length`: (Optional) The length of the /XX CIDR range to request. for example 24 for a /24. Prefix length must be between 2 and 29 for IPv4 and 48 and 64 for IPv6.
 
 Type:
 
 ```hcl
 list(object({
-    id            = string
-    prefix_length = number
+    id                     = string
+    number_of_ip_addresses = optional(string)
+    prefix_length          = optional(number)
   }))
 ```
 
@@ -574,7 +576,8 @@ Description: (Optional) A map of subnets to create
  - `address_prefixes` - (Optional) The address prefixes to use for the subnet. One of `address_prefix`, `address_prefixes`, or `ipam_pools` must be specified.
  - `ipam_pools` - (Optional) IPAM pools to allocate address space from. When specified, the subnet will request address space from these pools. Each pool configuration supports:
    - `pool_id`: Resource ID of the IPAM pool to allocate from
-   - `prefix_length`: The CIDR prefix length for this subnet (e.g., 24 for /24, 26 for /26)
+   - `number_of_ip_addresses`: (Optional) The number of IP addresses to request from the IPAM pool. If not specified, it will be calculated based on the `prefix_length`.
+   - `prefix_length`: (Optional) The CIDR prefix length for this subnet (e.g., 24 for /24, 26 for /26)
    - `allocation_type`: Type of allocation - "Static" (default) or "Dynamic"
  - `enforce_private_link_endpoint_network_policies` -
  - `enforce_private_link_service_network_policies` -
@@ -640,9 +643,10 @@ map(object({
     address_prefixes = optional(list(string))
     name             = string
     ipam_pools = optional(list(object({
-      pool_id         = string
-      prefix_length   = optional(number)
-      allocation_type = optional(string, "Static")
+      pool_id                = string
+      number_of_ip_addresses = optional(string)
+      prefix_length          = optional(number)
+      allocation_type        = optional(string, "Static")
     })))
     nat_gateway = optional(object({
       id = string

--- a/examples/ipam_basic/README.md
+++ b/examples/ipam_basic/README.md
@@ -144,8 +144,8 @@ module "vnet_retry_test" {
   enable_telemetry = true
   # VNet gets address space from IPAM pool
   ipam_pools = [{
-    id            = azapi_resource.ipam_pool.id
-    prefix_length = 24 # /24 VNet (256 IP addresses)
+    id                     = azapi_resource.ipam_pool.id
+    number_of_ip_addresses = "256"
   }]
   name = "${module.naming.virtual_network.name_unique}-retry-test"
   # Multiple IPAM subnets - this should test the retry logic
@@ -154,29 +154,29 @@ module "vnet_retry_test" {
     subnet1 = {
       name = "subnet1-retry-test"
       ipam_pools = [{
-        pool_id       = azapi_resource.ipam_pool.id
-        prefix_length = 26 # /26 (64 addresses)
+        pool_id                = azapi_resource.ipam_pool.id
+        number_of_ip_addresses = "64"
       }]
     }
     subnet2 = {
       name = "subnet2-retry-test"
       ipam_pools = [{
-        pool_id       = azapi_resource.ipam_pool.id
-        prefix_length = 26 # /26 (64 addresses) - may overlap with subnet1 initially
+        pool_id                = azapi_resource.ipam_pool.id
+        number_of_ip_addresses = "64"
       }]
     }
     subnet3 = {
       name = "subnet3-retry-test"
       ipam_pools = [{
-        pool_id       = azapi_resource.ipam_pool.id
-        prefix_length = 27 # /27 (32 addresses)
+        pool_id                = azapi_resource.ipam_pool.id
+        number_of_ip_addresses = "32"
       }]
     }
     subnet4 = {
       name = "subnet4-retry-test"
       ipam_pools = [{
-        pool_id       = azapi_resource.ipam_pool.id
-        prefix_length = 27 # /27 (32 addresses)
+        pool_id                = azapi_resource.ipam_pool.id
+        number_of_ip_addresses = "32"
       }]
     }
   }

--- a/examples/ipam_basic/main.tf
+++ b/examples/ipam_basic/main.tf
@@ -91,8 +91,8 @@ module "vnet_retry_test" {
   enable_telemetry = true
   # VNet gets address space from IPAM pool
   ipam_pools = [{
-    id            = azapi_resource.ipam_pool.id
-    prefix_length = 24 # /24 VNet (256 IP addresses)
+    id                     = azapi_resource.ipam_pool.id
+    number_of_ip_addresses = "256"
   }]
   name = "${module.naming.virtual_network.name_unique}-retry-test"
   # Multiple IPAM subnets - this should test the retry logic
@@ -101,29 +101,29 @@ module "vnet_retry_test" {
     subnet1 = {
       name = "subnet1-retry-test"
       ipam_pools = [{
-        pool_id       = azapi_resource.ipam_pool.id
-        prefix_length = 26 # /26 (64 addresses)
+        pool_id                = azapi_resource.ipam_pool.id
+        number_of_ip_addresses = "64"
       }]
     }
     subnet2 = {
       name = "subnet2-retry-test"
       ipam_pools = [{
-        pool_id       = azapi_resource.ipam_pool.id
-        prefix_length = 26 # /26 (64 addresses) - may overlap with subnet1 initially
+        pool_id                = azapi_resource.ipam_pool.id
+        number_of_ip_addresses = "64"
       }]
     }
     subnet3 = {
       name = "subnet3-retry-test"
       ipam_pools = [{
-        pool_id       = azapi_resource.ipam_pool.id
-        prefix_length = 27 # /27 (32 addresses)
+        pool_id                = azapi_resource.ipam_pool.id
+        number_of_ip_addresses = "32"
       }]
     }
     subnet4 = {
       name = "subnet4-retry-test"
       ipam_pools = [{
-        pool_id       = azapi_resource.ipam_pool.id
-        prefix_length = 27 # /27 (32 addresses)
+        pool_id                = azapi_resource.ipam_pool.id
+        number_of_ip_addresses = "32"
       }]
     }
   }

--- a/examples/ipam_vnet_only/README.md
+++ b/examples/ipam_vnet_only/README.md
@@ -270,8 +270,8 @@ module "vnet_ipam_traditional_subnets" {
   enable_telemetry = true
   # VNet address space allocated from IPAM pool
   ipam_pools = [{
-    id            = azapi_resource.ipam_pool.id
-    prefix_length = 16 # /16 VNet from the /12 pool
+    id                     = azapi_resource.ipam_pool.id
+    number_of_ip_addresses = "65536" # /16 VNet from the /12 pool
   }]
   name = "${module.naming.virtual_network.name_unique}-ipam-vnet"
   # Traditional subnets with static addressing (IPAM VNet gets dynamic space)

--- a/examples/ipam_vnet_only/main.tf
+++ b/examples/ipam_vnet_only/main.tf
@@ -120,8 +120,8 @@ module "vnet_ipam_traditional_subnets" {
   enable_telemetry = true
   # VNet address space allocated from IPAM pool
   ipam_pools = [{
-    id            = azapi_resource.ipam_pool.id
-    prefix_length = 16 # /16 VNet from the /12 pool
+    id                     = azapi_resource.ipam_pool.id
+    number_of_ip_addresses = "65536" # /16 VNet from the /12 pool
   }]
   name = "${module.naming.virtual_network.name_unique}-ipam-vnet"
   # Traditional subnets with static addressing (IPAM VNet gets dynamic space)

--- a/main.interfaces.tf
+++ b/main.interfaces.tf
@@ -57,11 +57,4 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
       category_group = enabled_log.value
     }
   }
-  dynamic "enabled_metric" {
-    for_each = each.value.metric_categories
-
-    content {
-      category = enabled_metric.value
-    }
-  }
 }

--- a/main.telemetry.tf
+++ b/main.telemetry.tf
@@ -1,4 +1,3 @@
-
 data "modtm_module_source" "telemetry" {
   count = var.enable_telemetry ? 1 : 0
 
@@ -20,6 +19,7 @@ resource "modtm_telemetry" "telemetry" {
     random_id       = one(random_uuid.telemetry).result
   }, { location = local.main_location })
 }
+
 locals {
   fork_avm = !anytrue([for r in local.valid_module_source_regex : can(regex(r, one(data.modtm_module_source.telemetry).module_source))])
 }
@@ -53,7 +53,7 @@ locals {
   # tflint-ignore: terraform_unused_declarations
   avm_azapi_header = join(" ", [for k, v in local.avm_azapi_headers : "${k}=${v}"])
 }
+
 data "azapi_client_config" "telemetry" {
   count = var.enable_telemetry ? 1 : 0
 }
-

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ resource "azapi_resource" "vnet" {
         var.ipam_pools != null ? {
           ipamPoolPrefixAllocations = [
             for ipam_pool in var.ipam_pools : {
-              numberOfIpAddresses = tostring(pow(2, (ipam_pool.prefix_length >= 48 ? 128 : 32) - ipam_pool.prefix_length))
+              numberOfIpAddresses = ipam_pool.number_of_ip_addresses != null ? ipam_pool.number_of_ip_addresses : tostring(pow(2, (ipam_pool.prefix_length >= 48 ? 128 : 32) - ipam_pool.prefix_length))
               pool = {
                 id = ipam_pool.id
               }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,3 @@
-
-
 resource "azapi_resource" "vnet" {
   location  = var.location
   name      = var.name
@@ -62,5 +60,3 @@ resource "azapi_resource" "vnet" {
     update = var.timeouts.update
   }
 }
-
-

--- a/modules/subnet/README.md
+++ b/modules/subnet/README.md
@@ -233,7 +233,8 @@ Default: `null`
 Description: (Optional) A list of IPAM pools to allocate subnet address space from. Each pool supports the following:
 
 - `pool_id` - (Required) The ID of the IPAM pool to allocate from.
-- `prefix_length` - (Required) The prefix length for the subnet allocation (e.g., 24 for a /24 subnet).
+- `number_of_ip_addresses` - (Optional) The number of IP addresses to request from the IPAM pool. If not specified, it will be calculated based on the `prefix_length`.
+- `prefix_length` - (Optional) The prefix length for the subnet allocation (e.g., 24 for a /24 subnet). Required if `number_of_ip_addresses` is not specified.
 
 Note: Only one IPAM pool allocation per subnet is currently supported. When using IPAM pools, do not specify `address_prefix` or `address_prefixes`.
 
@@ -241,8 +242,9 @@ Type:
 
 ```hcl
 list(object({
-    pool_id       = string
-    prefix_length = number
+    pool_id                = string
+    number_of_ip_addresses = optional(string)
+    prefix_length          = optional(number)
   }))
 ```
 

--- a/modules/subnet/ipam.tf
+++ b/modules/subnet/ipam.tf
@@ -11,7 +11,7 @@ resource "azapi_resource" "subnet_ipam" {
           pool = {
             id = pool.pool_id
           }
-          numberOfIpAddresses = tostring(
+          numberOfIpAddresses = pool.number_of_ip_addresses != null ? pool.number_of_ip_addresses : tostring(
             pool.prefix_length <= 32
             ? pow(2, 32 - pool.prefix_length) # IPv4 calculation
             : 0                               # IPv6 - Azure uses 0 for IPv6 pools

--- a/modules/subnet/variables.tf
+++ b/modules/subnet/variables.tf
@@ -82,15 +82,17 @@ DESCRIPTION
 
 variable "ipam_pools" {
   type = list(object({
-    pool_id       = string
-    prefix_length = number
+    pool_id                = string
+    number_of_ip_addresses = optional(string)
+    prefix_length          = optional(number)
   }))
   default     = null
   description = <<DESCRIPTION
 (Optional) A list of IPAM pools to allocate subnet address space from. Each pool supports the following:
 
 - `pool_id` - (Required) The ID of the IPAM pool to allocate from.
-- `prefix_length` - (Required) The prefix length for the subnet allocation (e.g., 24 for a /24 subnet).
+- `number_of_ip_addresses` - (Optional) The number of IP addresses to request from the IPAM pool. If not specified, it will be calculated based on the `prefix_length`.
+- `prefix_length` - (Optional) The prefix length for the subnet allocation (e.g., 24 for a /24 subnet). Required if `number_of_ip_addresses` is not specified.
 
 Note: Only one IPAM pool allocation per subnet is currently supported. When using IPAM pools, do not specify `address_prefix` or `address_prefixes`.
 DESCRIPTION
@@ -100,8 +102,8 @@ DESCRIPTION
     error_message = "Only one IPAM pool allocation per subnet is supported."
   }
   validation {
-    condition     = var.ipam_pools == null ? true : alltrue([for pool in var.ipam_pools : pool.prefix_length >= 16 && pool.prefix_length <= 30])
-    error_message = "IPAM pool prefix_length must be between 16 and 30 for IPv4 subnets."
+    condition     = var.ipam_pools == null ? true : alltrue([for pool in var.ipam_pools : pool.number_of_ip_addresses != null || (pool.prefix_length != null && pool.prefix_length >= 16 && pool.prefix_length <= 30)])
+    error_message = "Either number_of_ip_addresses or a prefix_length between 16 and 30 must be specified for each IPAM pool."
   }
 }
 

--- a/tests/unit/ipam_validations.tftest.hcl
+++ b/tests/unit/ipam_validations.tftest.hcl
@@ -1,0 +1,163 @@
+# Unit tests for the root `ipam_pools` variable validations (SNFR4).
+# Runs at plan time with mocked providers - no Azure resources are deployed.
+# Execute with: ./avm tf-test-unit
+
+mock_provider "azapi" {}
+mock_provider "azurerm" {}
+mock_provider "modtm" {}
+mock_provider "random" {}
+
+variables {
+  name             = "vnet-unit-test"
+  location         = "westeurope"
+  parent_id        = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg"
+  enable_telemetry = false
+}
+
+# --- Valid configurations (plan must succeed) ---
+
+run "valid_number_of_ip_addresses_only" {
+  command = plan
+
+  variables {
+    ipam_pools = [{
+      id                     = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkManagers/test-nm/ipamPools/test-pool"
+      number_of_ip_addresses = "256"
+    }]
+  }
+}
+
+run "valid_prefix_length_only" {
+  command = plan
+
+  variables {
+    ipam_pools = [{
+      id            = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkManagers/test-nm/ipamPools/test-pool"
+      prefix_length = 24
+    }]
+  }
+}
+
+# Guards #65: dot is a valid character in an IPAM pool name.
+run "valid_pool_id_with_dot" {
+  command = plan
+
+  variables {
+    ipam_pools = [{
+      id            = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkManagers/test-nm/ipamPools/ipam-nm-10.197.0.0-16-shr"
+      prefix_length = 24
+    }]
+  }
+}
+
+# One IPv4 + one IPv6 pool is the maximum allowed dual-stack configuration.
+run "valid_one_ipv4_and_one_ipv6_pool" {
+  command = plan
+
+  variables {
+    ipam_pools = [
+      {
+        id            = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkManagers/test-nm/ipamPools/pool-v4"
+        prefix_length = 24
+      },
+      {
+        id            = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkManagers/test-nm/ipamPools/pool-v6"
+        prefix_length = 64
+      }
+    ]
+  }
+}
+
+# --- Invalid configurations (validation must fail) ---
+
+# A pool with neither number_of_ip_addresses nor prefix_length.
+run "invalid_neither_field_set" {
+  command = plan
+
+  variables {
+    ipam_pools = [{
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkManagers/test-nm/ipamPools/test-pool"
+    }]
+  }
+
+  expect_failures = [var.ipam_pools]
+}
+
+run "invalid_two_ipv4_pools" {
+  command = plan
+
+  variables {
+    ipam_pools = [
+      {
+        id            = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkManagers/test-nm/ipamPools/pool-a"
+        prefix_length = 24
+      },
+      {
+        id            = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkManagers/test-nm/ipamPools/pool-b"
+        prefix_length = 26
+      }
+    ]
+  }
+
+  expect_failures = [var.ipam_pools]
+}
+
+# Guards the IPv6 alignment fix: /56 must be classified as IPv6 (range 48-64),
+# so two IPv6 pools are rejected. Before the fix, only /64 was counted and this
+# would wrongly pass.
+run "invalid_two_ipv6_pools" {
+  command = plan
+
+  variables {
+    ipam_pools = [
+      {
+        id            = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkManagers/test-nm/ipamPools/pool-v6a"
+        prefix_length = 56
+      },
+      {
+        id            = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkManagers/test-nm/ipamPools/pool-v6b"
+        prefix_length = 64
+      }
+    ]
+  }
+
+  expect_failures = [var.ipam_pools]
+}
+
+# More than two pools, isolated to the length rule by using number_of_ip_addresses
+# only (so the per-family prefix_length checks do not also fire).
+run "invalid_more_than_two_pools" {
+  command = plan
+
+  variables {
+    ipam_pools = [
+      {
+        id                     = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkManagers/test-nm/ipamPools/pool-1"
+        number_of_ip_addresses = "256"
+      },
+      {
+        id                     = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkManagers/test-nm/ipamPools/pool-2"
+        number_of_ip_addresses = "256"
+      },
+      {
+        id                     = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkManagers/test-nm/ipamPools/pool-3"
+        number_of_ip_addresses = "256"
+      }
+    ]
+  }
+
+  expect_failures = [var.ipam_pools]
+}
+
+run "invalid_pool_id_format" {
+  command = plan
+
+  variables {
+    ipam_pools = [{
+      id            = "not-a-valid-resource-id"
+      prefix_length = 24
+    }]
+  }
+
+  expect_failures = [var.ipam_pools]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -193,7 +193,7 @@ DESCRIPTION
 
   validation {
     condition = alltrue([
-      for ipam_pool in var.ipam_pools != null ? var.ipam_pools : [] : can(regex("^\\/subscriptions\\/[\\w-]+\\/resourceGroups\\/[\\w-]+\\/providers\\/Microsoft\\.Network\\/networkManagers\\/[\\w-]+\\/ipamPools\\/[\\w-]+$", ipam_pool.id))
+      for ipam_pool in var.ipam_pools != null ? var.ipam_pools : [] : can(regex("^\\/subscriptions\\/[\\w-]+\\/resourceGroups\\/[\\w-]+\\/providers\\/Microsoft\\.Network\\/networkManagers\\/[\\w-]+\\/ipamPools\\/[\\w\\.-]+$", ipam_pool.id))
     ]) || var.ipam_pools == null
     error_message = "IPAM pool ID must be a valid ipamPools resource ID."
   }

--- a/variables.tf
+++ b/variables.tf
@@ -206,6 +206,12 @@ DESCRIPTION
     error_message = "Prefix length must be between 2 and 29 for IPv4 and 48 and 64 for IPv6."
   }
   validation {
+    condition = alltrue([
+      for ipam_pool in var.ipam_pools != null ? var.ipam_pools : [] : ipam_pool.number_of_ip_addresses != null || ipam_pool.prefix_length != null
+    ]) || var.ipam_pools == null
+    error_message = "Each IPAM pool entry must specify either number_of_ip_addresses or prefix_length."
+  }
+  validation {
     condition     = var.ipam_pools == null || (length(var.ipam_pools) >= 1 && length(var.ipam_pools) <= 2)
     error_message = "Only one or two IPAM pools can be specified."
   }

--- a/variables.tf
+++ b/variables.tf
@@ -180,15 +180,17 @@ DESCRIPTION
 
 variable "ipam_pools" {
   type = list(object({
-    id            = string
-    prefix_length = number
+    id                     = string
+    number_of_ip_addresses = optional(string)
+    prefix_length          = optional(number)
   }))
   default     = null
   description = <<DESCRIPTION
 (Optional) Specifies the IPAM settings for requesting an address_space from an IP Pool. Only one IPv4 and one IPv6 pool can be specified.
 
 - `id`: The ID of the IPAM pool.
-- `prefix_length`: The length of the /XX CIDR range to request. for example 24 for a /24. Prefix length must be between 2 and 29 for IPv4 and 48 and 64 for IPv6.
+- `number_of_ip_addresses`: (Optional) The number of IP addresses to request from the IPAM pool. If not specified, it will be calculated based on the `prefix_length`.
+- `prefix_length`: (Optional) The length of the /XX CIDR range to request. for example 24 for a /24. Prefix length must be between 2 and 29 for IPv4 and 48 and 64 for IPv6.
 DESCRIPTION
 
   validation {
@@ -199,14 +201,12 @@ DESCRIPTION
   }
   validation {
     condition = alltrue([
-      for ipam_pool in var.ipam_pools != null ? var.ipam_pools : [] : (ipam_pool.prefix_length >= 2 && ipam_pool.prefix_length <= 29) || (ipam_pool.prefix_length >= 48 && ipam_pool.prefix_length <= 64)
+      for ipam_pool in var.ipam_pools != null ? var.ipam_pools : [] : ipam_pool.prefix_length != null ? (ipam_pool.prefix_length >= 2 && ipam_pool.prefix_length <= 29) || (ipam_pool.prefix_length >= 48 && ipam_pool.prefix_length <= 64) : true
     ]) || var.ipam_pools == null
     error_message = "Prefix length must be between 2 and 29 for IPv4 and 48 and 64 for IPv6."
   }
   validation {
-    condition = alltrue([
-      for ipam_pool in var.ipam_pools != null ? var.ipam_pools : [] : length(ipam_pool) >= 1 && length(ipam_pool) <= 2
-    ]) || var.ipam_pools == null
+    condition     = var.ipam_pools == null || (length(var.ipam_pools) >= 1 && length(var.ipam_pools) <= 2)
     error_message = "Only one or two IPAM pools can be specified."
   }
   validation {
@@ -217,7 +217,7 @@ DESCRIPTION
   }
   validation {
     condition = length([
-      for ipam_pool in var.ipam_pools != null ? var.ipam_pools : [] : ipam_pool if ipam_pool.prefix_length >= 2 && ipam_pool.prefix_length <= 29
+      for ipam_pool in var.ipam_pools != null ? var.ipam_pools : [] : ipam_pool if ipam_pool.prefix_length != null ? ipam_pool.prefix_length >= 2 && ipam_pool.prefix_length <= 29 : false
     ]) <= 1 || var.ipam_pools == null
     error_message = "Only one IPv4 pool can be specified."
   }
@@ -404,9 +404,10 @@ variable "subnets" {
     address_prefixes = optional(list(string))
     name             = string
     ipam_pools = optional(list(object({
-      pool_id         = string
-      prefix_length   = optional(number)
-      allocation_type = optional(string, "Static")
+      pool_id                = string
+      number_of_ip_addresses = optional(string)
+      prefix_length          = optional(number)
+      allocation_type        = optional(string, "Static")
     })))
     nat_gateway = optional(object({
       id = string
@@ -464,7 +465,8 @@ variable "subnets" {
  - `address_prefixes` - (Optional) The address prefixes to use for the subnet. One of `address_prefix`, `address_prefixes`, or `ipam_pools` must be specified.
  - `ipam_pools` - (Optional) IPAM pools to allocate address space from. When specified, the subnet will request address space from these pools. Each pool configuration supports:
    - `pool_id`: Resource ID of the IPAM pool to allocate from
-   - `prefix_length`: The CIDR prefix length for this subnet (e.g., 24 for /24, 26 for /26)
+   - `number_of_ip_addresses`: (Optional) The number of IP addresses to request from the IPAM pool. If not specified, it will be calculated based on the `prefix_length`.
+   - `prefix_length`: (Optional) The CIDR prefix length for this subnet (e.g., 24 for /24, 26 for /26)
    - `allocation_type`: Type of allocation - "Static" (default) or "Dynamic"
  - `enforce_private_link_endpoint_network_policies` -
  - `enforce_private_link_service_network_policies` -

--- a/variables.tf
+++ b/variables.tf
@@ -217,7 +217,7 @@ DESCRIPTION
   }
   validation {
     condition = length([
-      for ipam_pool in var.ipam_pools != null ? var.ipam_pools : [] : ipam_pool if ipam_pool.prefix_length == 64
+      for ipam_pool in var.ipam_pools != null ? var.ipam_pools : [] : ipam_pool if ipam_pool.prefix_length != null ? ipam_pool.prefix_length >= 48 && ipam_pool.prefix_length <= 64 : false
     ]) <= 1 || var.ipam_pools == null
     error_message = "Only one IPv6 pool can be specified."
   }


### PR DESCRIPTION
## Summary

Release branch bundling several community-contributed IPAM fixes plus maintainer follow-ups for the IPAM pool passthrough feature. External fork PRs cannot run the AVM CI directly, so the valid module-code changes were reimplemented here on an owner-controlled release branch (preserving original authorship), excluding any AVM-team-managed scaffolding.

## What's included

| Change | Original contributor | Source PR / Issue |
| --- | --- | --- |
| Fix regex for IPAM pool ID validation | @walkerk1980 (Keith Walker) | #65 |
| Pass through `number_of_ip_addresses` for IPAM pools (root + subnet) | @timja (Tim Jacomb) | #67 (closes #66) |
| Require `number_of_ip_addresses` **or** `prefix_length` per IPAM pool (XOR validation) | @martinopedal (Martin Opedal) | #67 |
| Stop emitting unsupported `enabled_metric` for virtual networks (interface-compliant) | @deni-cpu / @martinopedal | #69 |
| Align IPv6 pool validation with IPv4 (full /48–/64 range, null-guarded) | @haflidif (maintainer) | — |
| Unit tests for `ipam_pools` variable validations (`terraform test`) | @haflidif (maintainer) | — |
| Apply avmfix/mapotf whitespace normalization | maintainer (tooling) | — |

Original authorship is preserved on each commit; co-authors are credited via `Co-authored-by` trailers.

## Validation performed locally

- `./avm pre-commit` — green (docs + mapotf normalization)
- `./avm pr-check` **linting** — green: avmfix, terraform-docs, **TFLint AVM interface-compliance**, Conftest config
- `terraform test -test-directory=tests/unit` — **9/9 pass**

The **well-architected** (`terraform plan` per example) stage was not runnable locally on Windows (the Linux CI container can't read the Windows MSAL token cache); it runs here in CI via the repo's OIDC identity.

## Notes / context

- The Azure AVNM IPAM API allows **one IPv4 + one IPv6 pool max per VNet**, **no duplicate pools**, and **no mixing IPAM with static prefixes** (per closed PR #71). The existing single-pool-per-family validations are therefore correct; the "allow 4 pools" / #102 direction is not supported by the API and is intentionally **not** included.
- #69 is implemented in an **interface-compliant** way: the `metric_categories` variable field is retained (required by the AVM diagnostic-settings interface), and only the `enabled_metric` dynamic block — which errors at apply for VNets — is removed.
- #70 is intentionally **parked** for a later, separate change.

## Scope guardrails

No AVM-team-managed scaffolding was modified (`avm/`, `.agents/skills/**`, etc.). Files changed: root `main.tf`, `variables.tf`, `main.interfaces.tf`, `README.md`, the two affected `examples/*`, `modules/subnet/*`, the `main.telemetry.tf`/`main.tf` whitespace normalization, and the new `tests/unit/ipam_validations.tftest.hcl`.

Closes #65, #66, #67, #69.
