### PR TITLE
docs: clarify IPAM allocation rules and pool constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The module supports:
 - Assigning delegations to subnets
 - **IPAM pool allocation for virtual network address space**
 - **IPAM pool allocation for individual subnets**
-- **Mixed IPAM and traditional addressing within the same virtual network**
+- **Choice of IPAM or traditional static addressing per virtual network**
 
 ## IPAM Support
 
@@ -36,8 +36,7 @@ This module provides comprehensive IPAM (IP Address Management) support through 
 ### What IPAM Provides
 - **VNet address space allocation** from centralized IPAM pools
 - **Subnet address allocation** from IPAM pools
-- **Multiple pool support** for IPv4 and IPv6 addressing
-- **Mixed addressing** - combine IPAM and traditional subnets in the same VNet
+- **Dual-stack support** - one IPv4 pool and one IPv6 pool per virtual network
 - **All standard subnet features** work with IPAM subnets (NSGs, service endpoints, delegations, etc.)
 
 ### Benefits
@@ -56,6 +55,21 @@ This module provides comprehensive IPAM (IP Address Management) support through 
 - **[ipam\_basic](examples/ipam\_basic/)** - Complete IPAM usage with VNet and multiple subnets
 - **[existing\_vnet\_ipam\_subnets](examples/existing\_vnet\_ipam\_subnets/)** - Adding IPAM subnets to existing VNet managed by IPAM
 - **[ipam\_vnet\_only](examples/ipam\_vnet\_only/)** - IPAM VNet creation without subnets
+
+### IPAM Allocation Rules and Sizing
+
+Address space is requested from an IPAM pool as a **single allocation per pool**. The following are enforced by the Azure Resource Provider (they are platform rules, not module limitations):
+
+| Rule | Detail |
+|------|--------|
+| One pool per IP type | At most one IPv4 pool and one IPv6 pool per virtual network. |
+| No duplicate pools | The same pool cannot be referenced more than once on a VNet or subnet. |
+| No IPAM + static mix | A virtual network uses either IPAM pools or a static `address_space`, not both. |
+| Subnet pools are a subset | A subnet may only reference pools that its virtual network already uses. |
+
+**Sizing:** set the size on the single pool entry using either `number_of_ip_addresses` (for example `"256"`) or `prefix_length` (for example `24`). To request more address space from a pool, increase that value - do **not** add a second entry for the same pool.
+
+**Resolved prefixes (summarization vs. fragmentation):** Azure resolves one allocation into one or more CIDR blocks. Contiguous free space is summarized into a single larger prefix (for example two `/21` worth of space surface as one `/20`); fragmented free space is returned as multiple non-adjacent prefixes (for example a single allocation may surface as `/25` + `/28`). This is why one pool can show a varying number of address prefixes. The module exposes these resolved prefixes as a **read-only** output, so summarization or fragmentation does **not** cause Terraform drift.
 
 ## Prerequisites
 
@@ -162,6 +176,11 @@ module "avm-res-network-subnet" {
 - **"Network Manager not found"**: Ensure Azure Virtual Network Manager exists before creating IPAM pools
 - **"Subnet overlap errors"**: Module uses retry logic to handle allocation conflicts automatically
 - **"Pool exhausted"**: Check that your IPAM pool has sufficient available address space for the requested subnets
+- **`CannotHaveDuplicatePoolIds`**: The same pool is referenced more than once. Use a single `ipam_pools` entry and increase `number_of_ip_addresses` instead of adding duplicate entries.
+- **`only one association of each IP type is allowed`**: Only one IPv4 pool and one IPv6 pool are permitted per virtual network. Remove the additional same-family pool.
+- **`CannotMixAddressPrefixAndPoolInPayload`**: A virtual network cannot combine IPAM pools with a static `address_space`. Choose one addressing model.
+- **`SubnetPoolsMustBeSubsetOfVnetPools`**: A subnet references a pool that its virtual network does not use. Reference the pool on the VNet first.
+- **A single pool shows multiple or changing address prefixes**: Expected behavior. One allocation is resolved into one or more CIDRs (summarized when contiguous, split when fragmented). These resolved prefixes are read-only and do not cause Terraform drift.
 ```
 ```
 

--- a/_header.md
+++ b/_header.md
@@ -25,7 +25,7 @@ The module supports:
 - Assigning delegations to subnets
 - **IPAM pool allocation for virtual network address space**
 - **IPAM pool allocation for individual subnets**
-- **Mixed IPAM and traditional addressing within the same virtual network**
+- **Choice of IPAM or traditional static addressing per virtual network**
 
 ## IPAM Support
 
@@ -34,8 +34,7 @@ This module provides comprehensive IPAM (IP Address Management) support through 
 ### What IPAM Provides
 - **VNet address space allocation** from centralized IPAM pools
 - **Subnet address allocation** from IPAM pools
-- **Multiple pool support** for IPv4 and IPv6 addressing
-- **Mixed addressing** - combine IPAM and traditional subnets in the same VNet
+- **Dual-stack support** - one IPv4 pool and one IPv6 pool per virtual network
 - **All standard subnet features** work with IPAM subnets (NSGs, service endpoints, delegations, etc.)
 
 ### Benefits
@@ -54,6 +53,21 @@ This module provides comprehensive IPAM (IP Address Management) support through 
 - **[ipam_basic](examples/ipam_basic/)** - Complete IPAM usage with VNet and multiple subnets
 - **[existing_vnet_ipam_subnets](examples/existing_vnet_ipam_subnets/)** - Adding IPAM subnets to existing VNet managed by IPAM
 - **[ipam_vnet_only](examples/ipam_vnet_only/)** - IPAM VNet creation without subnets
+
+### IPAM Allocation Rules and Sizing
+
+Address space is requested from an IPAM pool as a **single allocation per pool**. The following are enforced by the Azure Resource Provider (they are platform rules, not module limitations):
+
+| Rule | Detail |
+|------|--------|
+| One pool per IP type | At most one IPv4 pool and one IPv6 pool per virtual network. |
+| No duplicate pools | The same pool cannot be referenced more than once on a VNet or subnet. |
+| No IPAM + static mix | A virtual network uses either IPAM pools or a static `address_space`, not both. |
+| Subnet pools are a subset | A subnet may only reference pools that its virtual network already uses. |
+
+**Sizing:** set the size on the single pool entry using either `number_of_ip_addresses` (for example `"256"`) or `prefix_length` (for example `24`). To request more address space from a pool, increase that value - do **not** add a second entry for the same pool.
+
+**Resolved prefixes (summarization vs. fragmentation):** Azure resolves one allocation into one or more CIDR blocks. Contiguous free space is summarized into a single larger prefix (for example two `/21` worth of space surface as one `/20`); fragmented free space is returned as multiple non-adjacent prefixes (for example a single allocation may surface as `/25` + `/28`). This is why one pool can show a varying number of address prefixes. The module exposes these resolved prefixes as a **read-only** output, so summarization or fragmentation does **not** cause Terraform drift.
 
 ## Prerequisites
 
@@ -160,4 +174,9 @@ module "avm-res-network-subnet" {
 - **"Network Manager not found"**: Ensure Azure Virtual Network Manager exists before creating IPAM pools
 - **"Subnet overlap errors"**: Module uses retry logic to handle allocation conflicts automatically
 - **"Pool exhausted"**: Check that your IPAM pool has sufficient available address space for the requested subnets
+- **`CannotHaveDuplicatePoolIds`**: The same pool is referenced more than once. Use a single `ipam_pools` entry and increase `number_of_ip_addresses` instead of adding duplicate entries.
+- **`only one association of each IP type is allowed`**: Only one IPv4 pool and one IPv6 pool are permitted per virtual network. Remove the additional same-family pool.
+- **`CannotMixAddressPrefixAndPoolInPayload`**: A virtual network cannot combine IPAM pools with a static `address_space`. Choose one addressing model.
+- **`SubnetPoolsMustBeSubsetOfVnetPools`**: A subnet references a pool that its virtual network does not use. Reference the pool on the VNet first.
+- **A single pool shows multiple or changing address prefixes**: Expected behavior. One allocation is resolved into one or more CIDRs (summarized when contiguous, split when fragmented). These resolved prefixes are read-only and do not cause Terraform drift.
 ```


### PR DESCRIPTION
## Description

Documentation-only change that clarifies how IPAM pool allocation actually works on virtual networks and subnets, based on hands-on verification against the live Azure API (`2025-09-01`).

### Why

Several issues/PRs (#66, #102, #71) stemmed from a common misunderstanding: that a VNet can attach *multiple* IPAM pools of the same IP family, or that the portal can do something the module cannot. In reality the Azure Resource Provider allows **one IPv4 pool + one IPv6 pool per VNet**, rejects duplicate pools, and resolves a **single** allocation into one or more address prefixes (summarized when contiguous, fragmented when not). The previous docs wording (`"Multiple pool support"`, `"Mixed IPAM and traditional addressing within the same virtual network"`) reinforced that confusion.

### Changes (in `_header.md`, README regenerated)

- Clarify the feature wording: `Dual-stack support` = one IPv4 + one IPv6 pool; `Choice of IPAM or traditional static addressing per virtual network`.
- New **IPAM Allocation Rules and Sizing** section: the RP constraint table (one pool per IP type, no duplicate pools, no IPAM/static mix, subnet pools ⊆ VNet pools), sizing via `number_of_ip_addresses` / `prefix_length`, and the summarization-vs-fragmentation behavior with a note that resolved `addressPrefixes` are read-only (no Terraform drift).
- Expand **Common IPAM Issues** with the actual RP error codes and fixes: `CannotHaveDuplicatePoolIds`, `only one association of each IP type is allowed`, `CannotMixAddressPrefixAndPoolInPayload`, `SubnetPoolsMustBeSubsetOfVnetPools`.

No code or behavior changes. `README.md` regenerated via terraform-docs.

## Type of Change

- [x] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all pre-commit checks
