### PR TITLE
chore(deps): consolidate Dependabot example dependency bumps

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -36,7 +36,7 @@ provider "azurerm" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # This is required for resource modules
@@ -351,13 +351,13 @@ The following Modules are called:
 
 Source: Azure/naming/azurerm
 
-Version: 0.4.2
+Version: 0.4.3
 
 ### <a name="module_regions"></a> [regions](#module\_regions)
 
 Source: Azure/avm-utl-regions/azurerm
 
-Version: 0.9.0
+Version: 0.12.0
 
 ### <a name="module_vnet1"></a> [vnet1](#module\_vnet1)
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -29,7 +29,7 @@ provider "azurerm" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # This is required for resource modules

--- a/examples/complete/region_selection.tf
+++ b/examples/complete/region_selection.tf
@@ -1,6 +1,6 @@
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
-  version = "0.9.0"
+  version = "0.12.0"
 
   is_recommended = true
 }

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -31,7 +31,7 @@ provider "azurerm" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # This is required for resource modules
@@ -91,13 +91,13 @@ The following Modules are called:
 
 Source: Azure/naming/azurerm
 
-Version: 0.4.2
+Version: 0.4.3
 
 ### <a name="module_regions"></a> [regions](#module\_regions)
 
 Source: Azure/avm-utl-regions/azurerm
 
-Version: 0.9.0
+Version: 0.12.0
 
 ### <a name="module_vnet"></a> [vnet](#module\_vnet)
 

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -24,7 +24,7 @@ provider "azurerm" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # This is required for resource modules

--- a/examples/default/region_selection.tf
+++ b/examples/default/region_selection.tf
@@ -1,6 +1,6 @@
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
-  version = "0.9.0"
+  version = "0.12.0"
 
   is_recommended = true
 }

--- a/examples/existing_vnet_ipam_subnets/README.md
+++ b/examples/existing_vnet_ipam_subnets/README.md
@@ -119,7 +119,7 @@ provider "azurerm" {
 
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 resource "azurerm_resource_group" "this" {
@@ -326,13 +326,13 @@ Version:
 
 Source: Azure/naming/azurerm
 
-Version: 0.4.2
+Version: 0.4.3
 
 ### <a name="module_regions"></a> [regions](#module\_regions)
 
 Source: Azure/avm-utl-regions/azurerm
 
-Version: 0.9.0
+Version: 0.12.0
 
 ### <a name="module_traditional_subnet"></a> [traditional\_subnet](#module\_traditional\_subnet)
 

--- a/examples/existing_vnet_ipam_subnets/main.tf
+++ b/examples/existing_vnet_ipam_subnets/main.tf
@@ -27,7 +27,7 @@ provider "azurerm" {
 
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 resource "azurerm_resource_group" "this" {

--- a/examples/existing_vnet_ipam_subnets/region_selection.tf
+++ b/examples/existing_vnet_ipam_subnets/region_selection.tf
@@ -1,6 +1,6 @@
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
-  version = "0.9.0"
+  version = "0.12.0"
 }
 
 # This allows us to randomize the region for the resource group.

--- a/examples/existing_vnet_peering/README.md
+++ b/examples/existing_vnet_peering/README.md
@@ -31,7 +31,7 @@ provider "azurerm" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # This is required for resource modules
@@ -114,7 +114,7 @@ The following Modules are called:
 
 Source: Azure/naming/azurerm
 
-Version: 0.4.2
+Version: 0.4.3
 
 ### <a name="module_peering"></a> [peering](#module\_peering)
 
@@ -126,7 +126,7 @@ Version:
 
 Source: Azure/avm-utl-regions/azurerm
 
-Version: 0.9.0
+Version: 0.12.0
 
 ## Usage
 

--- a/examples/existing_vnet_peering/main.tf
+++ b/examples/existing_vnet_peering/main.tf
@@ -24,7 +24,7 @@ provider "azurerm" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # This is required for resource modules

--- a/examples/existing_vnet_peering/region_selection.tf
+++ b/examples/existing_vnet_peering/region_selection.tf
@@ -1,6 +1,6 @@
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
-  version = "0.9.0"
+  version = "0.12.0"
 
   is_recommended = true
 }

--- a/examples/existing_vnet_peering_sync_address_space/README.md
+++ b/examples/existing_vnet_peering_sync_address_space/README.md
@@ -30,7 +30,7 @@ provider "azurerm" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # This is required for resource modules
@@ -122,7 +122,7 @@ The following Modules are called:
 
 Source: Azure/naming/azurerm
 
-Version: 0.4.2
+Version: 0.4.3
 
 ### <a name="module_peering"></a> [peering](#module\_peering)
 
@@ -134,7 +134,7 @@ Version:
 
 Source: Azure/avm-utl-regions/azurerm
 
-Version: 0.9.0
+Version: 0.12.0
 
 ## Usage
 

--- a/examples/existing_vnet_peering_sync_address_space/main.tf
+++ b/examples/existing_vnet_peering_sync_address_space/main.tf
@@ -24,7 +24,7 @@ provider "azurerm" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # This is required for resource modules

--- a/examples/existing_vnet_peering_sync_address_space/region_selection.tf
+++ b/examples/existing_vnet_peering_sync_address_space/region_selection.tf
@@ -1,6 +1,6 @@
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
-  version = "0.9.0"
+  version = "0.12.0"
 
   is_recommended = true
 }

--- a/examples/existing_vnet_subnets/README.md
+++ b/examples/existing_vnet_subnets/README.md
@@ -31,7 +31,7 @@ provider "azurerm" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # This is required for resource modules
@@ -108,13 +108,13 @@ The following Modules are called:
 
 Source: Azure/naming/azurerm
 
-Version: 0.4.2
+Version: 0.4.3
 
 ### <a name="module_regions"></a> [regions](#module\_regions)
 
 Source: Azure/avm-utl-regions/azurerm
 
-Version: 0.9.0
+Version: 0.12.0
 
 ### <a name="module_subnets"></a> [subnets](#module\_subnets)
 

--- a/examples/existing_vnet_subnets/main.tf
+++ b/examples/existing_vnet_subnets/main.tf
@@ -24,7 +24,7 @@ provider "azurerm" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # This is required for resource modules

--- a/examples/existing_vnet_subnets/region_selection.tf
+++ b/examples/existing_vnet_subnets/region_selection.tf
@@ -1,6 +1,6 @@
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
-  version = "0.9.0"
+  version = "0.12.0"
 
   is_recommended = true
 }

--- a/examples/ipam_basic/README.md
+++ b/examples/ipam_basic/README.md
@@ -80,7 +80,7 @@ provider "azurerm" {
 
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 resource "azurerm_resource_group" "this" {
@@ -235,13 +235,13 @@ The following Modules are called:
 
 Source: Azure/naming/azurerm
 
-Version: 0.4.2
+Version: 0.4.3
 
 ### <a name="module_regions"></a> [regions](#module\_regions)
 
 Source: Azure/avm-utl-regions/azurerm
 
-Version: 0.9.0
+Version: 0.12.0
 
 ### <a name="module_vnet_retry_test"></a> [vnet\_retry\_test](#module\_vnet\_retry\_test)
 

--- a/examples/ipam_basic/main.tf
+++ b/examples/ipam_basic/main.tf
@@ -27,7 +27,7 @@ provider "azurerm" {
 
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 resource "azurerm_resource_group" "this" {

--- a/examples/ipam_basic/region_selection.tf
+++ b/examples/ipam_basic/region_selection.tf
@@ -1,6 +1,6 @@
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
-  version = "0.9.0"
+  version = "0.12.0"
 }
 
 # This allows us to randomize the region for the resource group.

--- a/examples/ipam_vnet_only/README.md
+++ b/examples/ipam_vnet_only/README.md
@@ -177,7 +177,7 @@ provider "azurerm" {
 
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 resource "azurerm_resource_group" "this" {
@@ -402,13 +402,13 @@ Version:
 
 Source: Azure/naming/azurerm
 
-Version: 0.4.2
+Version: 0.4.3
 
 ### <a name="module_regions"></a> [regions](#module\_regions)
 
 Source: Azure/avm-utl-regions/azurerm
 
-Version: 0.9.0
+Version: 0.12.0
 
 ### <a name="module_vnet_ipam_traditional_subnets"></a> [vnet\_ipam\_traditional\_subnets](#module\_vnet\_ipam\_traditional\_subnets)
 

--- a/examples/ipam_vnet_only/main.tf
+++ b/examples/ipam_vnet_only/main.tf
@@ -27,7 +27,7 @@ provider "azurerm" {
 
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 resource "azurerm_resource_group" "this" {

--- a/examples/ipam_vnet_only/region_selection.tf
+++ b/examples/ipam_vnet_only/region_selection.tf
@@ -1,6 +1,6 @@
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
-  version = "0.9.0"
+  version = "0.12.0"
 }
 
 # This allows us to randomize the region for the resource group.

--- a/examples/legacy_address_prefix/README.md
+++ b/examples/legacy_address_prefix/README.md
@@ -31,7 +31,7 @@ provider "azurerm" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # This is required for resource modules
@@ -123,13 +123,13 @@ The following Modules are called:
 
 Source: Azure/naming/azurerm
 
-Version: 0.4.2
+Version: 0.4.3
 
 ### <a name="module_regions"></a> [regions](#module\_regions)
 
 Source: Azure/avm-utl-regions/azurerm
 
-Version: 0.9.0
+Version: 0.12.0
 
 ### <a name="module_vnet"></a> [vnet](#module\_vnet)
 

--- a/examples/legacy_address_prefix/main.tf
+++ b/examples/legacy_address_prefix/main.tf
@@ -24,7 +24,7 @@ provider "azurerm" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # This is required for resource modules

--- a/examples/legacy_address_prefix/region_selection.tf
+++ b/examples/legacy_address_prefix/region_selection.tf
@@ -1,6 +1,6 @@
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
-  version = "0.9.0"
+  version = "0.12.0"
 
   is_recommended = true
 }

--- a/examples/new_route/README.md
+++ b/examples/new_route/README.md
@@ -31,7 +31,7 @@ provider "azurerm" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # This is required for resource modules
@@ -121,13 +121,13 @@ The following Modules are called:
 
 Source: Azure/naming/azurerm
 
-Version: 0.4.2
+Version: 0.4.3
 
 ### <a name="module_regions"></a> [regions](#module\_regions)
 
 Source: Azure/avm-utl-regions/azurerm
 
-Version: 0.9.0
+Version: 0.12.0
 
 ### <a name="module_vnet"></a> [vnet](#module\_vnet)
 

--- a/examples/new_route/main.tf
+++ b/examples/new_route/main.tf
@@ -24,7 +24,7 @@ provider "azurerm" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # This is required for resource modules

--- a/examples/new_route/region_selection.tf
+++ b/examples/new_route/region_selection.tf
@@ -1,6 +1,6 @@
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
-  version = "0.9.0"
+  version = "0.12.0"
 
   is_recommended = true
 }

--- a/examples/new_security_rule/README.md
+++ b/examples/new_security_rule/README.md
@@ -35,7 +35,7 @@ provider "azurerm" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # This is required for resource modules
@@ -138,13 +138,13 @@ The following Modules are called:
 
 Source: Azure/naming/azurerm
 
-Version: 0.4.2
+Version: 0.4.3
 
 ### <a name="module_regions"></a> [regions](#module\_regions)
 
 Source: Azure/avm-utl-regions/azurerm
 
-Version: 0.9.0
+Version: 0.12.0
 
 ### <a name="module_vnet"></a> [vnet](#module\_vnet)
 

--- a/examples/new_security_rule/main.tf
+++ b/examples/new_security_rule/main.tf
@@ -28,7 +28,7 @@ provider "azurerm" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # This is required for resource modules

--- a/examples/new_security_rule/region_selection.tf
+++ b/examples/new_security_rule/region_selection.tf
@@ -1,6 +1,6 @@
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
-  version = "0.9.0"
+  version = "0.12.0"
 
   is_recommended = true
 }

--- a/examples/peer_only_specified_address_spaces/README.md
+++ b/examples/peer_only_specified_address_spaces/README.md
@@ -31,7 +31,7 @@ provider "azurerm" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # This is required for resource modules
@@ -196,13 +196,13 @@ The following Modules are called:
 
 Source: Azure/naming/azurerm
 
-Version: 0.4.2
+Version: 0.4.3
 
 ### <a name="module_regions"></a> [regions](#module\_regions)
 
 Source: Azure/avm-utl-regions/azurerm
 
-Version: 0.9.0
+Version: 0.12.0
 
 ### <a name="module_vnet1"></a> [vnet1](#module\_vnet1)
 

--- a/examples/peer_only_specified_address_spaces/main.tf
+++ b/examples/peer_only_specified_address_spaces/main.tf
@@ -24,7 +24,7 @@ provider "azurerm" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # This is required for resource modules

--- a/examples/peer_only_specified_address_spaces/region_selection.tf
+++ b/examples/peer_only_specified_address_spaces/region_selection.tf
@@ -1,6 +1,6 @@
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
-  version = "0.9.0"
+  version = "0.12.0"
 
   is_recommended = true
 }

--- a/examples/peer_only_specified_subnets/README.md
+++ b/examples/peer_only_specified_subnets/README.md
@@ -35,7 +35,7 @@ provider "azurerm" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # This is required for resource modules
@@ -208,13 +208,13 @@ The following Modules are called:
 
 Source: Azure/naming/azurerm
 
-Version: 0.4.2
+Version: 0.4.3
 
 ### <a name="module_regions"></a> [regions](#module\_regions)
 
 Source: Azure/avm-utl-regions/azurerm
 
-Version: 0.9.0
+Version: 0.12.0
 
 ### <a name="module_vnet1"></a> [vnet1](#module\_vnet1)
 

--- a/examples/peer_only_specified_subnets/main.tf
+++ b/examples/peer_only_specified_subnets/main.tf
@@ -28,7 +28,7 @@ provider "azurerm" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # This is required for resource modules

--- a/examples/peer_only_specified_subnets/region_selection.tf
+++ b/examples/peer_only_specified_subnets/region_selection.tf
@@ -1,6 +1,6 @@
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
-  version = "0.9.0"
+  version = "0.12.0"
 
   is_recommended = true
 }

--- a/examples/service_endpoints_with_locations/README.md
+++ b/examples/service_endpoints_with_locations/README.md
@@ -165,7 +165,7 @@ The following Modules are called:
 
 Source: Azure/avm-utl-regions/azurerm
 
-Version: 0.9.0
+Version: 0.12.0
 
 ### <a name="module_virtualnetwork"></a> [virtualnetwork](#module\_virtualnetwork)
 

--- a/examples/service_endpoints_with_locations/region_selection.tf
+++ b/examples/service_endpoints_with_locations/region_selection.tf
@@ -1,6 +1,6 @@
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
-  version = "0.9.0"
+  version = "0.12.0"
 
   has_pair       = true
   is_recommended = true

--- a/examples/with_network_interface/README.md
+++ b/examples/with_network_interface/README.md
@@ -31,7 +31,7 @@ provider "azurerm" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # This is required for resource modules
@@ -110,13 +110,13 @@ The following Modules are called:
 
 Source: Azure/naming/azurerm
 
-Version: 0.4.2
+Version: 0.4.3
 
 ### <a name="module_regions"></a> [regions](#module\_regions)
 
 Source: Azure/avm-utl-regions/azurerm
 
-Version: 0.9.0
+Version: 0.12.0
 
 ### <a name="module_vnet"></a> [vnet](#module\_vnet)
 

--- a/examples/with_network_interface/main.tf
+++ b/examples/with_network_interface/main.tf
@@ -24,7 +24,7 @@ provider "azurerm" {
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
   source  = "Azure/naming/azurerm"
-  version = "0.4.2"
+  version = "0.4.3"
 }
 
 # This is required for resource modules

--- a/examples/with_network_interface/region_selection.tf
+++ b/examples/with_network_interface/region_selection.tf
@@ -1,6 +1,6 @@
 module "regions" {
   source  = "Azure/avm-utl-regions/azurerm"
-  version = "0.9.0"
+  version = "0.12.0"
 
   is_recommended = true
 }


### PR DESCRIPTION
## Description

Consolidates the open Dependabot dependency PRs into a single change to avoid 27 separate CI runs and merges. All updates are to **example-only** helper modules — no impact on the module itself, its inputs, outputs, or consumers.

### Updates
| Module | From | To |
| --- | --- | --- |
| `Azure/avm-utl-regions/azurerm` | 0.9.0 | 0.12.0 |
| `Azure/naming/azurerm` | 0.4.2 | 0.4.3 |

Applied across all `examples/*` (`main.tf` + `region_selection.tf`) and example READMEs regenerated via terraform-docs.

### Supersedes
Replaces the following Dependabot PRs, which will be closed once this merges:
#73, #74, #75, #76, #77, #78, #79, #80, #81, #82, #83, #84, #85, #86, #87, #88, #89, #90, #91, #92, #93, #94, #95, #96, #97, #98, #99, #100, #101

### Validation
- `./avm pre-commit` green (fmt, validate, docs-sync).
- Diff is purely version bumps; both target versions are the latest published on the Terraform Registry.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
