### PR TITLE
feat!: convert lock, RBAC and diagnostic settings to azapi via avm-utl-interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.4)
 
 - <a name="requirement_modtm"></a> [modtm](#requirement\_modtm) (~> 0.3)
 

--- a/README.md
+++ b/README.md
@@ -191,9 +191,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.4)
-
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
 
 - <a name="requirement_modtm"></a> [modtm](#requirement\_modtm) (~> 0.3)
 
@@ -203,10 +201,10 @@ The following requirements are needed by this module:
 
 The following resources are used by this module:
 
+- [azapi_resource.diagnostic_settings](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
+- [azapi_resource.lock](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
+- [azapi_resource.role_assignments](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
 - [azapi_resource.vnet](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
-- [azurerm_management_lock.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) (resource)
-- [azurerm_monitor_diagnostic_setting.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) (resource)
-- [azurerm_role_assignment.vnet_level](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) (resource)
 - [modtm_telemetry.telemetry](https://registry.terraform.io/providers/azure/modtm/latest/docs/resources/telemetry) (resource)
 - [random_uuid.telemetry](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) (resource)
 - [azapi_client_config.telemetry](https://registry.terraform.io/providers/Azure/azapi/latest/docs/data-sources/client_config) (data source)
@@ -779,6 +777,12 @@ Please refer to the subnet module documentation for details of the outputs
 ## Modules
 
 The following Modules are called:
+
+### <a name="module_interfaces"></a> [interfaces](#module\_interfaces)
+
+Source: Azure/avm-utl-interfaces/azure
+
+Version: 0.6.0
 
 ### <a name="module_peering"></a> [peering](#module\_peering)
 

--- a/locals.tf
+++ b/locals.tf
@@ -1,3 +1,5 @@
 locals {
-  role_definition_resource_substring = "/providers/Microsoft.Authorization/roleDefinitions"
+  # Subscription scope used by the interfaces module to resolve role definition
+  # names to resource ids. Derived from the resource group parent_id.
+  role_assignment_definition_scope = "/subscriptions/${split("/", var.parent_id)[2]}"
 }

--- a/main.interfaces.tf
+++ b/main.interfaces.tf
@@ -1,11 +1,37 @@
-# Applying Management Lock to the Virtual Network if specified.
-resource "azurerm_management_lock" "this" {
-  count = (var.lock != null ? 1 : 0)
+# Shared AVM interfaces (lock, role assignments, diagnostic settings) transformed
+# into azapi resource payloads via the avm-utl-interfaces utility module.
+module "interfaces" {
+  source  = "Azure/avm-utl-interfaces/azure"
+  version = "0.6.0"
 
-  lock_level = var.lock.kind
-  name       = coalesce(var.lock.name, "lock-${var.lock.kind}")
-  scope      = azapi_resource.vnet.id
-  notes      = var.lock.kind == "CanNotDelete" ? "Cannot delete the resource or its child resources." : "Cannot delete or modify the resource or its child resources."
+  diagnostic_settings              = var.diagnostic_settings
+  enable_telemetry                 = var.enable_telemetry
+  lock                             = var.lock
+  role_assignment_definition_scope = local.role_assignment_definition_scope
+  role_assignments                 = var.role_assignments
+}
+
+# Applying Management Lock to the Virtual Network if specified.
+resource "azapi_resource" "lock" {
+  count = var.lock != null ? 1 : 0
+
+  name                   = coalesce(module.interfaces.lock_azapi.name, "lock-${var.lock.kind}")
+  parent_id              = azapi_resource.vnet.id
+  type                   = module.interfaces.lock_azapi.type
+  body                   = module.interfaces.lock_azapi.body
+  create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  response_export_values = []
+  retry                  = var.retry
+  update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  timeouts {
+    create = var.timeouts.create
+    delete = var.timeouts.delete
+    read   = var.timeouts.read
+    update = var.timeouts.update
+  }
 
   depends_on = [
     azapi_resource.vnet,
@@ -14,47 +40,71 @@ resource "azurerm_management_lock" "this" {
   ]
 }
 
-resource "azurerm_role_assignment" "vnet_level" {
-  for_each = var.role_assignments
+resource "azapi_resource" "role_assignments" {
+  for_each = module.interfaces.role_assignments_azapi
 
-  principal_id                           = each.value.principal_id
-  scope                                  = azapi_resource.vnet.id
-  condition                              = each.value.condition
-  condition_version                      = each.value.condition_version
-  delegated_managed_identity_resource_id = each.value.delegated_managed_identity_resource_id
-  role_definition_id                     = strcontains(lower(each.value.role_definition_id_or_name), lower(local.role_definition_resource_substring)) ? each.value.role_definition_id_or_name : null
-  role_definition_name                   = strcontains(lower(each.value.role_definition_id_or_name), lower(local.role_definition_resource_substring)) ? null : each.value.role_definition_id_or_name
-  skip_service_principal_aad_check       = each.value.skip_service_principal_aad_check
+  name                   = each.value.name
+  parent_id              = azapi_resource.vnet.id
+  type                   = each.value.type
+  body                   = each.value.body
+  create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  response_export_values = []
+  retry                  = var.retry
+  update_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+
+  timeouts {
+    create = var.timeouts.create
+    delete = var.timeouts.delete
+    read   = var.timeouts.read
+    update = var.timeouts.update
+  }
 
   depends_on = [
     azapi_resource.vnet
   ]
 }
 
-resource "azurerm_monitor_diagnostic_setting" "this" {
-  for_each = var.diagnostic_settings
+resource "azapi_resource" "diagnostic_settings" {
+  for_each = module.interfaces.diagnostic_settings_azapi
 
-  name                           = each.value.name != null ? each.value.name : "diag-${var.name}"
-  target_resource_id             = azapi_resource.vnet.id
-  eventhub_authorization_rule_id = each.value.event_hub_authorization_rule_resource_id
-  eventhub_name                  = each.value.event_hub_name
-  log_analytics_destination_type = each.value.log_analytics_destination_type == "Dedicated" ? null : each.value.log_analytics_destination_type
-  log_analytics_workspace_id     = each.value.workspace_resource_id
-  partner_solution_id            = each.value.marketplace_partner_resource_id
-  storage_account_id             = each.value.storage_account_resource_id
+  name                      = coalesce(each.value.name, "diag-${var.name}")
+  parent_id                 = azapi_resource.vnet.id
+  type                      = each.value.type
+  body                      = each.value.body
+  create_headers            = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  delete_headers            = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_null_property      = true
+  read_headers              = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  response_export_values    = []
+  retry                     = var.retry
+  schema_validation_enabled = false
+  update_headers            = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
 
-  dynamic "enabled_log" {
-    for_each = each.value.log_categories
-
-    content {
-      category = enabled_log.value
-    }
+  timeouts {
+    create = var.timeouts.create
+    delete = var.timeouts.delete
+    read   = var.timeouts.read
+    update = var.timeouts.update
   }
-  dynamic "enabled_log" {
-    for_each = each.value.log_groups
 
-    content {
-      category_group = enabled_log.value
-    }
-  }
+  depends_on = [
+    azapi_resource.vnet
+  ]
+}
+
+moved {
+  from = azurerm_management_lock.this[0]
+  to   = azapi_resource.lock[0]
+}
+
+moved {
+  from = azurerm_role_assignment.vnet_level
+  to   = azapi_resource.role_assignments
+}
+
+moved {
+  from = azurerm_monitor_diagnostic_setting.this
+  to   = azapi_resource.diagnostic_settings
 }

--- a/main.interfaces.tf
+++ b/main.interfaces.tf
@@ -49,6 +49,7 @@ resource "azapi_resource" "role_assignments" {
   body                   = each.value.body
   create_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   delete_headers         = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
+  ignore_null_property   = true
   read_headers           = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null
   response_export_values = []
   retry                  = var.retry

--- a/modules/subnet/README.md
+++ b/modules/subnet/README.md
@@ -127,17 +127,15 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.5)
-
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
 
 ## Resources
 
 The following resources are used by this module:
 
+- [azapi_resource.role_assignments](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/resource) (resource)
 - [azapi_resource.subnet](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/resource) (resource)
 - [azapi_resource.subnet_ipam](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/resource) (resource)
-- [azurerm_role_assignment.subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) (resource)
 
 <!-- markdownlint-disable MD013 -->
 ## Required Inputs
@@ -446,7 +444,13 @@ Description: The resource ID of the subnet.
 
 ## Modules
 
-No modules.
+The following Modules are called:
+
+### <a name="module_interfaces"></a> [interfaces](#module\_interfaces)
+
+Source: Azure/avm-utl-interfaces/azure
+
+Version: 0.6.0
 
 <!-- markdownlint-disable-next-line MD041 -->
 ## Data Collection

--- a/modules/subnet/README.md
+++ b/modules/subnet/README.md
@@ -127,7 +127,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.5)
 
 ## Resources
 

--- a/modules/subnet/locals.tf
+++ b/modules/subnet/locals.tf
@@ -1,6 +1,8 @@
 locals {
-  ipam_enabled                       = var.ipam_pools != null
-  role_definition_resource_substring = "/providers/Microsoft.Authorization/roleDefinitions"
+  ipam_enabled = var.ipam_pools != null
+  # Subscription scope used by the interfaces module to resolve role definition
+  # names to resource ids. Derived from the virtual network parent_id.
+  role_assignment_definition_scope = "/subscriptions/${split("/", var.parent_id)[2]}"
 }
 
 locals {

--- a/modules/subnet/main.tf
+++ b/modules/subnet/main.tf
@@ -53,15 +53,29 @@ moved {
   to   = azapi_resource.subnet[0]
 }
 
-resource "azurerm_role_assignment" "subnet" {
-  for_each = var.role_assignments
+resource "azapi_resource" "role_assignments" {
+  for_each = module.interfaces.role_assignments_azapi
 
-  principal_id                           = each.value.principal_id
-  scope                                  = local.ipam_enabled ? azapi_resource.subnet_ipam[0].id : azapi_resource.subnet[0].id
-  condition                              = each.value.condition
-  condition_version                      = each.value.condition_version
-  delegated_managed_identity_resource_id = each.value.delegated_managed_identity_resource_id
-  role_definition_id                     = strcontains(lower(each.value.role_definition_id_or_name), lower(local.role_definition_resource_substring)) ? each.value.role_definition_id_or_name : null
-  role_definition_name                   = strcontains(lower(each.value.role_definition_id_or_name), lower(local.role_definition_resource_substring)) ? null : each.value.role_definition_id_or_name
-  skip_service_principal_aad_check       = each.value.skip_service_principal_aad_check
+  name                   = each.value.name
+  parent_id              = local.ipam_enabled ? azapi_resource.subnet_ipam[0].id : azapi_resource.subnet[0].id
+  type                   = each.value.type
+  body                   = each.value.body
+  response_export_values = []
+  retry                  = var.retry
+}
+
+# Shared AVM interfaces (role assignments) transformed into azapi resource
+# payloads via the avm-utl-interfaces utility module.
+module "interfaces" {
+  source  = "Azure/avm-utl-interfaces/azure"
+  version = "0.6.0"
+
+  enable_telemetry                 = false
+  role_assignment_definition_scope = local.role_assignment_definition_scope
+  role_assignments                 = var.role_assignments
+}
+
+moved {
+  from = azurerm_role_assignment.subnet
+  to   = azapi_resource.role_assignments
 }

--- a/modules/subnet/main.tf
+++ b/modules/subnet/main.tf
@@ -60,6 +60,7 @@ resource "azapi_resource" "role_assignments" {
   parent_id              = local.ipam_enabled ? azapi_resource.subnet_ipam[0].id : azapi_resource.subnet[0].id
   type                   = each.value.type
   body                   = each.value.body
+  ignore_null_property   = true
   response_export_values = []
   retry                  = var.retry
 }

--- a/modules/subnet/terraform.tf
+++ b/modules/subnet/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.5"
     }
   }
 }

--- a/modules/subnet/terraform.tf
+++ b/modules/subnet/terraform.tf
@@ -4,11 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "azure/azapi"
-      version = "~> 2.5"
-    }
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 4.0"
+      version = "~> 2.9"
     }
   }
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.9"
+      version = "~> 2.4"
     }
     modtm = {
       source  = "azure/modtm"

--- a/terraform.tf
+++ b/terraform.tf
@@ -4,11 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.4"
-    }
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 4.0"
+      version = "~> 2.9"
     }
     modtm = {
       source  = "azure/modtm"

--- a/tests/unit/ipam_validations.tftest.hcl
+++ b/tests/unit/ipam_validations.tftest.hcl
@@ -3,7 +3,6 @@
 # Execute with: ./avm tf-test-unit
 
 mock_provider "azapi" {}
-mock_provider "azurerm" {}
 mock_provider "modtm" {}
 mock_provider "random" {}
 


### PR DESCRIPTION
## Description

Converts the module's shared AVM interfaces — **management lock**, **role assignments** and **diagnostic settings** — from `azurerm_*` resources to `azapi_resource` payloads generated by the [`Azure/avm-utl-interfaces`](https://registry.terraform.io/modules/Azure/avm-utl-interfaces/azure/latest) utility module (v0.6.0). This aligns the module with the current AVM standard for azapi-primary modules (the same pattern used by `avm-res-resources-resourcegroup` and `avm-res-storage-storageaccount`), and **removes the `azurerm` provider dependency from the module entirely**.

This continues the work started by @kewalaka in #52, now that the required azapi capability has shipped (azapi `>= 2.9`, upstream `azapi#995`).

### What changed

- `main.interfaces.tf`: single `module "interfaces"` call → `azapi_resource.lock`, `azapi_resource.role_assignments`, `azapi_resource.diagnostic_settings`, each with `moved` blocks from the old `azurerm_*` resources.
- `modules/subnet/main.tf`: subnet-level role assignments converted to `azapi_resource.role_assignments` (+ `moved` block).
- Removed the now-unused `role_definition_resource_substring` local (name→ID resolution is handled by the utility module).
- `terraform.tf` (root + subnet): removed the `azurerm` provider; bumped `azapi` to `~> 2.9`.
- READMEs regenerated by terraform-docs.

### Notes

- **`diagnostic_settings` input is unchanged.** The utility module's v1 diagnostic-settings schema is identical to the existing variable, so this is a non-breaking change for the diagnostics input.
- State is migrated cross-type via the azapi provider's `MoveResourceState` (Terraform ≥ 1.8; this module requires `>= 1.9`).

## ⚠️ Breaking change & upgrade guidance

Existing **role assignments will be recreated once** on upgrade: the generated resource name changes from the `azurerm`-managed GUID to the utility module's deterministic name. The grant is re-applied in the same apply (no lasting loss of access), but operators should **review the plan carefully** before applying in production.

Locks and diagnostic settings migrate in place with no recreation.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] My code follows the AVM standards and contribution guidelines

Closes #52
