### PR TITLE
Bump `azapi` floor to `~> 2.10` to avoid subnet delegation crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Address space is requested from an IPAM pool as a **single allocation per pool**
 ### For IPAM Features
 - **Azure Virtual Network Manager**: Required for all IPAM functionality
 - **Supported Azure region**: IPAM must be available in your target region (see [Regional Support](#ipam-regional-support))
-- **azapi provider**: Version ~> 2.4 required for IPAM resource management
+- **azapi provider**: Version ~> 2.10 required for IPAM resource management
 - **Proper permissions**: Network Manager and IPAM pool management permissions
 
 ## Usage
@@ -191,7 +191,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.4)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.10)
 
 - <a name="requirement_modtm"></a> [modtm](#requirement\_modtm) (~> 0.3)
 

--- a/_header.md
+++ b/_header.md
@@ -74,7 +74,7 @@ Address space is requested from an IPAM pool as a **single allocation per pool**
 ### For IPAM Features
 - **Azure Virtual Network Manager**: Required for all IPAM functionality
 - **Supported Azure region**: IPAM must be available in your target region (see [Regional Support](#ipam-regional-support))
-- **azapi provider**: Version ~> 2.4 required for IPAM resource management
+- **azapi provider**: Version ~> 2.10 required for IPAM resource management
 - **Proper permissions**: Network Manager and IPAM pool management permissions
 
 ## Usage

--- a/examples/existing_vnet_ipam_subnets/README.md
+++ b/examples/existing_vnet_ipam_subnets/README.md
@@ -256,7 +256,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9.2)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.4)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.10)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 

--- a/examples/existing_vnet_ipam_subnets/README.md
+++ b/examples/existing_vnet_ipam_subnets/README.md
@@ -96,7 +96,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.4"
+      version = "~> 2.10"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -256,7 +256,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9.2)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.4)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.10)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 

--- a/examples/existing_vnet_ipam_subnets/main.tf
+++ b/examples/existing_vnet_ipam_subnets/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.4"
+      version = "~> 2.10"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/ipam_basic/README.md
+++ b/examples/ipam_basic/README.md
@@ -57,7 +57,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.4"
+      version = "~> 2.10"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -190,7 +190,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9.2)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.4)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.10)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 

--- a/examples/ipam_basic/README.md
+++ b/examples/ipam_basic/README.md
@@ -190,7 +190,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9.2)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.4)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.10)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 

--- a/examples/ipam_basic/main.tf
+++ b/examples/ipam_basic/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.4"
+      version = "~> 2.10"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/ipam_vnet_only/README.md
+++ b/examples/ipam_vnet_only/README.md
@@ -154,7 +154,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.4"
+      version = "~> 2.10"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -357,7 +357,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9.2)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.4)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.10)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 

--- a/examples/ipam_vnet_only/README.md
+++ b/examples/ipam_vnet_only/README.md
@@ -357,7 +357,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9.2)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.4)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.10)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 

--- a/examples/ipam_vnet_only/main.tf
+++ b/examples/ipam_vnet_only/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.4"
+      version = "~> 2.10"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/peer_only_specified_address_spaces/README.md
+++ b/examples/peer_only_specified_address_spaces/README.md
@@ -152,7 +152,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.10)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 

--- a/examples/peer_only_specified_address_spaces/README.md
+++ b/examples/peer_only_specified_address_spaces/README.md
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.0"
+      version = "~> 2.10"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -152,7 +152,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.10)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 

--- a/examples/peer_only_specified_address_spaces/main.tf
+++ b/examples/peer_only_specified_address_spaces/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.0"
+      version = "~> 2.10"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/peer_only_specified_subnets/README.md
+++ b/examples/peer_only_specified_subnets/README.md
@@ -152,7 +152,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.10)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 

--- a/examples/peer_only_specified_subnets/README.md
+++ b/examples/peer_only_specified_subnets/README.md
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.0"
+      version = "~> 2.10"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -152,7 +152,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.10)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 

--- a/examples/peer_only_specified_subnets/main.tf
+++ b/examples/peer_only_specified_subnets/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.0"
+      version = "~> 2.10"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/modules/peering/README.md
+++ b/modules/peering/README.md
@@ -52,7 +52,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.10)
 
 ## Resources
 

--- a/modules/peering/terraform.tf
+++ b/modules/peering/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "azure/azapi"
-      version = "~> 2.0"
+      version = "~> 2.10"
     }
   }
 }

--- a/modules/subnet/README.md
+++ b/modules/subnet/README.md
@@ -73,7 +73,7 @@ For comprehensive multi-subnet IPAM scenarios with time-delayed sequential creat
 ### For IPAM Subnets
 - **IPAM-enabled Virtual Network**: Parent VNet must be created with IPAM pools (not traditional VNet)
 - **Azure Virtual Network Manager**: Required with IPAM pools configured
-- **azapi provider**: Version ~> 2.4 required for IPAM subnet operations
+- **azapi provider**: Version ~> 2.10 required for IPAM subnet operations
 
 ## Usage
 
@@ -127,7 +127,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.5)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.10)
 
 ## Resources
 

--- a/modules/subnet/_header.md
+++ b/modules/subnet/_header.md
@@ -71,7 +71,7 @@ For comprehensive multi-subnet IPAM scenarios with time-delayed sequential creat
 ### For IPAM Subnets
 - **IPAM-enabled Virtual Network**: Parent VNet must be created with IPAM pools (not traditional VNet)
 - **Azure Virtual Network Manager**: Required with IPAM pools configured
-- **azapi provider**: Version ~> 2.4 required for IPAM subnet operations
+- **azapi provider**: Version ~> 2.10 required for IPAM subnet operations
 
 ## Usage
 

--- a/modules/subnet/terraform.tf
+++ b/modules/subnet/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "azure/azapi"
-      version = "~> 2.5"
+      version = "~> 2.10"
     }
   }
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.4"
+      version = "~> 2.10"
     }
     modtm = {
       source  = "azure/modtm"


### PR DESCRIPTION
## Summary

Adding a `delegation` to an already-deployed subnet crashes the `azapi` provider with `runtime error: index out of range [0] with length 0` in `utils/json.go` (the `ModifyPlan` → `UpdateObject` path panics when the `delegations` list is non-empty). This is a provider bug in `azapi` ≤ v2.9.0, fixed in **v2.10.0** via [Azure/terraform-provider-azapi#1125](https://github.com/Azure/terraform-provider-azapi/pull/1125) — the same root cause the maintainer confirmed on the already-closed #68.

Our constraints (`~> 2.4` at root, `~> 2.5` in the subnet module, `~> 2.0` in peering) still allowed the crashing versions, so a fresh resolve could land a consumer on a broken provider. This raises the floor to `~> 2.10` (= `>= 2.10.0, < 3.0.0`) everywhere `azapi` is declared.

## Changes

- Root `terraform.tf`, `modules/subnet/terraform.tf`, `modules/peering/terraform.tf` → `~> 2.10`
- All four `examples/*/main.tf` that declare `azapi` — including `existing_vnet_ipam_subnets`, which is exactly this issue's scenario, so I didn't want to leave the crash in a copy-paste template
- Hand-written `azapi` version notes in `_header.md` and `modules/subnet/_header.md`, plus the regenerated README requirement lines to match

## Notes

- I couldn't run `./avm docs`/`fmt` locally (no `terraform`/`terraform-docs`/container runtime), so the README strings are hand-edited to match `terraform-docs` output. These are version-string edits within existing formatting, so `fmt` is a no-op; CI pre-commit will confirm.
- Existing consumers with a pinned `.terraform.lock.hcl` will still need `terraform init -upgrade` to pick up the fix; the floor bump just stops new resolves from landing on the crashing versions.

Fixes #63.