### PR TITLE
Register multi-peering feature in `peer_only_specified_address_spaces`

### DIFF
--- a/examples/peer_only_specified_address_spaces/README.md
+++ b/examples/peer_only_specified_address_spaces/README.md
@@ -9,6 +9,10 @@ terraform {
   required_version = ">= 1.9, < 2.0"
 
   required_providers {
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 2.0"
+    }
     azurerm = {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
@@ -134,6 +138,10 @@ module "vnet2" {
       address_prefixes = ["10.7.5.0/24", "10.7.6.0/24"]
     }
   }
+
+  depends_on = [
+    azapi_update_resource.allow_multiple_peering_links_between_vnets
+  ]
 }
 ```
 
@@ -144,6 +152,8 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
+
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 - <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.5)
@@ -152,8 +162,10 @@ The following requirements are needed by this module:
 
 The following resources are used by this module:
 
+- [azapi_update_resource.allow_multiple_peering_links_between_vnets](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/update_resource) (resource)
 - [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) (resource)
 - [random_integer.region_index](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) (resource)
+- [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) (data source)
 
 <!-- markdownlint-disable MD013 -->
 ## Required Inputs

--- a/examples/peer_only_specified_address_spaces/main.tf
+++ b/examples/peer_only_specified_address_spaces/main.tf
@@ -2,6 +2,10 @@ terraform {
   required_version = ">= 1.9, < 2.0"
 
   required_providers {
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 2.0"
+    }
     azurerm = {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
@@ -127,4 +131,8 @@ module "vnet2" {
       address_prefixes = ["10.7.5.0/24", "10.7.6.0/24"]
     }
   }
+
+  depends_on = [
+    azapi_update_resource.allow_multiple_peering_links_between_vnets
+  ]
 }

--- a/examples/peer_only_specified_address_spaces/prerequisites.tf
+++ b/examples/peer_only_specified_address_spaces/prerequisites.tf
@@ -1,0 +1,14 @@
+# This file contains prerequisite resources that must be registered before deploying the main example.
+# These feature registrations are required at the subscription level.
+
+# Register the feature to allow multiple peering links between VNets
+# This is required for partial-address-space peering scenarios (peer_complete_vnets = false)
+resource "azapi_update_resource" "allow_multiple_peering_links_between_vnets" {
+  resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.Features/featureProviders/Microsoft.Network/subscriptionFeatureRegistrations/AllowMultiplePeeringLinksBetweenVnets"
+  type        = "Microsoft.Features/featureProviders/subscriptionFeatureRegistrations@2021-07-01"
+  body = {
+    properties = {}
+  }
+}
+
+data "azurerm_client_config" "current" {}


### PR DESCRIPTION
Fixes #125.

## Why

The `peer_only_specified_address_spaces` e2e example fails in CI with `SubscriptionNotRegisteredForFeature` for the preview feature `Microsoft.Network/AllowMultiplePeeringLinksBetweenVnets`. That feature is required because this example does partial-address-space peering (`peer_complete_vnets = false`). This is a **pre-existing failure that blocks every PR** and is unrelated to the unit-test work in #122.

## How we got here

This isn't a classic "worked, then a commit broke it" regression — the example was born requiring an unregistered feature, and a later partial fix cemented the inconsistency:

- **Root cause — #112 (`0b9846893`, v0.4.0, 2024-07-26):** "Fix partial peering capability and defaults" created **both** partial-peering examples (`peer_only_specified_address_spaces` and `peer_only_specified_subnets`) with `peer_complete_vnets = false`, which requires `AllowMultiplePeeringLinksBetweenVnets` — but added **no** feature registration to either.
- **Divergence — #51 (`c08ca17f5`, v0.17.0, 2026-01-07):** "Handle addressPrefixes during subnet import" added `prerequisites.tf` + the `azapi` provider to register the feature for **`peer_only_specified_subnets` only** ("Add prerequisites.tf for subnet peering examples requiring AllowMultiplePeeringLinksBetweenVnets feature"), leaving this sibling example behind.

So the subnet example is green while this one is red purely because #51 fixed one of the two twins and missed the other. This PR finishes the job #51 started.

## What

This mirrors the fix already shipped for the sibling `peer_only_specified_subnets` example in `v0.17.0` (#51):

- Add a `prerequisites.tf` that registers the feature via `azapi_update_resource` against the `subscriptionFeatureRegistrations` resource (the correct API — not the provider `/register` endpoint), plus a `data.azurerm_client_config.current` for the subscription ID.
- Add `azapi` (`~> 2.0`) to the example's `required_providers`.
- Wire `depends_on` from `module "vnet2"` (the block that creates the peerings) onto the registration so it runs first.
- Regenerate the example `README.md` via terraform-docs.

## Validation

`terraform fmt -check`, `terraform init`, and `terraform validate` all pass in the example dir. A full `terraform apply` needs Azure credentials and is exercised by CI.

## Caveat

Feature registration is asynchronous and does not expose an LRO/`provisioningState`, so `depends_on` guarantees the registration call happens before the peering create but **not** that it has fully propagated. If CI is still red after this, some Network features additionally need a provider re-registration / propagation delay — the durable alternative is to register the feature on the CI test subscriptions out-of-band.