### PR TITLE
Bump `azapi` floor to `~> 2.11` to fix missing resource identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Address space is requested from an IPAM pool as a **single allocation per pool**
 ### For IPAM Features
 - **Azure Virtual Network Manager**: Required for all IPAM functionality
 - **Supported Azure region**: IPAM must be available in your target region (see [Regional Support](#ipam-regional-support))
-- **azapi provider**: Version ~> 2.10 required for IPAM resource management
+- **azapi provider**: Version ~> 2.11 required for IPAM resource management
 - **Proper permissions**: Network Manager and IPAM pool management permissions
 
 ## Usage
@@ -191,7 +191,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.10)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.11)
 
 - <a name="requirement_modtm"></a> [modtm](#requirement\_modtm) (~> 0.3)
 

--- a/_header.md
+++ b/_header.md
@@ -74,7 +74,7 @@ Address space is requested from an IPAM pool as a **single allocation per pool**
 ### For IPAM Features
 - **Azure Virtual Network Manager**: Required for all IPAM functionality
 - **Supported Azure region**: IPAM must be available in your target region (see [Regional Support](#ipam-regional-support))
-- **azapi provider**: Version ~> 2.10 required for IPAM resource management
+- **azapi provider**: Version ~> 2.11 required for IPAM resource management
 - **Proper permissions**: Network Manager and IPAM pool management permissions
 
 ## Usage

--- a/examples/existing_vnet_ipam_subnets/README.md
+++ b/examples/existing_vnet_ipam_subnets/README.md
@@ -96,7 +96,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.10"
+      version = "~> 2.11"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -251,7 +251,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9.2)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.10)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.11)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 

--- a/examples/existing_vnet_ipam_subnets/main.tf
+++ b/examples/existing_vnet_ipam_subnets/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.10"
+      version = "~> 2.11"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/ipam_basic/README.md
+++ b/examples/ipam_basic/README.md
@@ -57,7 +57,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.10"
+      version = "~> 2.11"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -190,7 +190,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9.2)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.10)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.11)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 

--- a/examples/ipam_basic/main.tf
+++ b/examples/ipam_basic/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.10"
+      version = "~> 2.11"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/ipam_vnet_only/README.md
+++ b/examples/ipam_vnet_only/README.md
@@ -154,7 +154,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.10"
+      version = "~> 2.11"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -343,7 +343,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9.2)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.10)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.11)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 

--- a/examples/ipam_vnet_only/main.tf
+++ b/examples/ipam_vnet_only/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.10"
+      version = "~> 2.11"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/peer_only_specified_address_spaces/README.md
+++ b/examples/peer_only_specified_address_spaces/README.md
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.10"
+      version = "~> 2.11"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -152,7 +152,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.10)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.11)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 

--- a/examples/peer_only_specified_address_spaces/main.tf
+++ b/examples/peer_only_specified_address_spaces/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.10"
+      version = "~> 2.11"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/examples/peer_only_specified_subnets/README.md
+++ b/examples/peer_only_specified_subnets/README.md
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.10"
+      version = "~> 2.11"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -152,7 +152,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.10)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.11)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 

--- a/examples/peer_only_specified_subnets/main.tf
+++ b/examples/peer_only_specified_subnets/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.10"
+      version = "~> 2.11"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/modules/peering/README.md
+++ b/modules/peering/README.md
@@ -52,7 +52,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.10)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.11)
 
 ## Resources
 

--- a/modules/peering/terraform.tf
+++ b/modules/peering/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "azure/azapi"
-      version = "~> 2.10"
+      version = "~> 2.11"
     }
   }
 }

--- a/modules/subnet/README.md
+++ b/modules/subnet/README.md
@@ -73,7 +73,7 @@ For comprehensive multi-subnet IPAM scenarios with time-delayed sequential creat
 ### For IPAM Subnets
 - **IPAM-enabled Virtual Network**: Parent VNet must be created with IPAM pools (not traditional VNet)
 - **Azure Virtual Network Manager**: Required with IPAM pools configured
-- **azapi provider**: Version ~> 2.10 required for IPAM subnet operations
+- **azapi provider**: Version ~> 2.11 required for IPAM subnet operations
 
 ## Usage
 
@@ -127,7 +127,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.10)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.11)
 
 ## Resources
 

--- a/modules/subnet/_header.md
+++ b/modules/subnet/_header.md
@@ -71,7 +71,7 @@ For comprehensive multi-subnet IPAM scenarios with time-delayed sequential creat
 ### For IPAM Subnets
 - **IPAM-enabled Virtual Network**: Parent VNet must be created with IPAM pools (not traditional VNet)
 - **Azure Virtual Network Manager**: Required with IPAM pools configured
-- **azapi provider**: Version ~> 2.10 required for IPAM subnet operations
+- **azapi provider**: Version ~> 2.11 required for IPAM subnet operations
 
 ## Usage
 

--- a/modules/subnet/terraform.tf
+++ b/modules/subnet/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "azure/azapi"
-      version = "~> 2.10"
+      version = "~> 2.11"
     }
   }
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.10"
+      version = "~> 2.11"
     }
     modtm = {
       source  = "azure/modtm"


### PR DESCRIPTION
## Description

Raises the `azapi` provider floor from `~> 2.10` to `~> 2.11` everywhere it is declared: the root module, subnet and peering submodules, and all five examples. Regenerated the affected READMEs.

This guarantees the upstream provider fix from Azure/terraform-provider-azapi#1156 for `Missing Resource Identity After Read` when a resource created with azapi v2.7.0 is later absent during read. There is no module-side resource behavior change; the defect was in the provider.

The new constraint remains within the `>= 2.0, < 3.0` range required by TFFR3. Consumers with an existing lock file must run `terraform init -upgrade` to select azapi v2.11.0 or newer.

Fixes #56.

## Validation

- `terraform init -backend=false` and `terraform validate` at the repository root, `modules/subnet`, and `modules/peering`
- Root unit tests: 18 passed
- Subnet unit tests: 5 passed
- Peering unit tests: 1 passed
- `./avm pre-commit` and `./avm pr-check` could not run because Docker is not installed in the local environment

_Drafted by Claude Opus 5._