### PR TITLE
docs: correct stale peerings variable documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,17 +520,16 @@ Description: (Optional) A map of virtual network peering configurations. Each en
 
  ---
  `timeouts` (Optional) supports the following:
- - `create` - (Defaults to 30 minutes) Used when creating the Subnet.
- - `delete` - (Defaults to 30 minutes) Used when deleting the Subnet.
- - `read` - (Defaults to 5 minutes) Used when retrieving the Subnet.
- - `update` - (Defaults to 30 minutes) Used when updating the Subnet.
+ - `create` - (Defaults to 30 minutes) Used when creating the Virtual Network Peering.
+ - `delete` - (Defaults to 30 minutes) Used when deleting the Virtual Network Peering.
+ - `read` - (Defaults to 5 minutes) Used when retrieving the Virtual Network Peering.
+ - `update` - (Defaults to 30 minutes) Used when updating the Virtual Network Peering.
 
 ---
   `retry` (Optional) supports the following:
   - `error_message_regex` - (Optional) A list of regular expressions to match against the error message returned by the API. If any of these match, the retry will be triggered.
   - `interval_seconds` - (Optional) The number of seconds to wait between retries. Defaults to 10.
   - `max_interval_seconds` - (Optional) The maximum number of seconds to wait between retries. Defaults to 180.
-  - `multiplier` - (Optional) The multiplier to apply to the interval between retries Defaults to 1.5.
 
 Type:
 

--- a/variables.tf
+++ b/variables.tf
@@ -349,17 +349,16 @@ variable "peerings" {
 
  ---
  `timeouts` (Optional) supports the following:
- - `create` - (Defaults to 30 minutes) Used when creating the Subnet.
- - `delete` - (Defaults to 30 minutes) Used when deleting the Subnet.
- - `read` - (Defaults to 5 minutes) Used when retrieving the Subnet.
- - `update` - (Defaults to 30 minutes) Used when updating the Subnet.
+ - `create` - (Defaults to 30 minutes) Used when creating the Virtual Network Peering.
+ - `delete` - (Defaults to 30 minutes) Used when deleting the Virtual Network Peering.
+ - `read` - (Defaults to 5 minutes) Used when retrieving the Virtual Network Peering.
+ - `update` - (Defaults to 30 minutes) Used when updating the Virtual Network Peering.
 
 ---
   `retry` (Optional) supports the following:
   - `error_message_regex` - (Optional) A list of regular expressions to match against the error message returned by the API. If any of these match, the retry will be triggered.
   - `interval_seconds` - (Optional) The number of seconds to wait between retries. Defaults to 10.
   - `max_interval_seconds` - (Optional) The maximum number of seconds to wait between retries. Defaults to 180.
-  - `multiplier` - (Optional) The multiplier to apply to the interval between retries Defaults to 1.5.
 
 DESCRIPTION
   nullable    = false


### PR DESCRIPTION
## Description

The `peerings` variable description documented a `retry.multiplier` option that the variable does not declare.

`multiplier` and `randomization_factor` were removed from every retry object in [v0.12.0](https://github.com/Azure/terraform-azurerm-avm-res-network-virtualnetwork/releases/tag/v0.12.0), but this one description block was missed. The generated README has advertised the option ever since, so a consumer following the docs and setting it gets `An argument named "multiplier" is not expected here`.

The nested `retry` object in `variable "peerings"` declares only:

```terraform
retry = optional(object({
  error_message_regex  = optional(list(string), ["ReferencedResourceNotProvisioned"])
  interval_seconds     = optional(number, 10)
  max_interval_seconds = optional(number, 180)
}), {})
```

The equivalent block in `variable "subnets"` is already correct and lists exactly those three, so this change brings `peerings` in line with it.

### Also included

The same description block described the nested `timeouts` object as applying to "the Subnet" — copy-pasted from the `subnets` variable. These timeouts apply to the virtual network peering. It is the same defect class on adjacent lines in the same heredoc, so fixing only the `multiplier` line would have left a known-wrong line immediately above it. Happy to split it out if you would rather keep the change to a single line.

## Scope

Documentation only. No variable types, defaults, validations, or resource behaviour change. `README.md` is regenerated with `terraform-docs`, not hand-edited, and its diff mirrors `variables.tf` exactly.

## Note on issue #109

This does **not** fix #109. That deprecation warning originates in the azapi provider's own schema, where `retry.multiplier` is `Optional`+`Computed` with a static default, and it surfaces through the AVM-required `output "resource"`. It cannot be fixed module-side. This PR only removes documentation for an input the module never accepted.

## Validation

- `terraform fmt -check -recursive` — clean
- `terraform validate` — `Success! The configuration is valid.`
- `terraform-docs -c .terraform-docs.yml .` — regenerated; the only remaining `multiplier` references in the repo are the historical v0.12.0 changelog rows in `_header.md`/`README.md`, which are correct as written

`./avm pre-commit` was not run locally because Docker is not installed in this environment.

_Drafted by Claude Opus 5._