### PR TITLE
feat: validate CIDR format on address_space, subnet, and peering inputs

### DIFF
--- a/modules/peering/tests/unit/cidr_validation.tftest.hcl
+++ b/modules/peering/tests/unit/cidr_validation.tftest.hcl
@@ -1,0 +1,65 @@
+# Unit tests for the peering submodule CIDR-format validation on the four
+# peered-address-space inputs (#136). Runs the peering submodule as its own
+# root at plan time with a mocked azapi provider - no Azure resources are
+# deployed. Run locally with:
+#   cd modules/peering && terraform test -test-directory ./tests/unit
+#
+# Direct submodule consumers must get the same guardrail as root-module callers:
+# a structurally invalid CIDR in any peered address space is rejected at plan
+# time rather than surfacing as an opaque Azure API error at apply.
+
+mock_provider "azapi" {}
+
+variables {
+  name                      = "peer-hub-to-spoke"
+  parent_id                 = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/hub-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet"
+  remote_virtual_network_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/spoke-rg/providers/Microsoft.Network/virtualNetworks/spoke-vnet"
+}
+
+run "valid_peered_address_spaces_accepted" {
+  command = plan
+
+  variables {
+    peer_complete_vnets          = false
+    local_peered_address_spaces  = [{ address_prefix = "10.0.0.0/24" }]
+    remote_peered_address_spaces = [{ address_prefix = "2001:db8::/64" }]
+  }
+}
+
+run "invalid_local_peered_address_space_rejected" {
+  command = plan
+
+  variables {
+    peer_complete_vnets          = false
+    local_peered_address_spaces  = [{ address_prefix = "10..0.0.0/25" }]
+    remote_peered_address_spaces = [{ address_prefix = "10.1.0.0/24" }]
+  }
+
+  expect_failures = [var.local_peered_address_spaces]
+}
+
+run "invalid_remote_peered_address_space_rejected" {
+  command = plan
+
+  variables {
+    peer_complete_vnets          = false
+    local_peered_address_spaces  = [{ address_prefix = "10.0.0.0/24" }]
+    remote_peered_address_spaces = [{ address_prefix = "not-a-cidr" }]
+  }
+
+  expect_failures = [var.remote_peered_address_spaces]
+}
+
+run "invalid_reverse_local_peered_address_space_rejected" {
+  command = plan
+
+  variables {
+    create_reverse_peering               = true
+    reverse_name                         = "peer-spoke-to-hub"
+    reverse_peer_complete_vnets          = false
+    reverse_local_peered_address_spaces  = [{ address_prefix = "10.0.0.0/99" }]
+    reverse_remote_peered_address_spaces = [{ address_prefix = "10.2.0.0/24" }]
+  }
+
+  expect_failures = [var.reverse_local_peered_address_spaces]
+}

--- a/modules/peering/variables.tf
+++ b/modules/peering/variables.tf
@@ -101,6 +101,11 @@ variable "local_peered_address_spaces" {
   }))
   default     = []
   description = "The address space of the local virtual network to peer. Only relevant if peer_complete_vnets is false"
+
+  validation {
+    condition     = alltrue([for a in(var.local_peered_address_spaces == null ? [] : var.local_peered_address_spaces) : can(cidrhost(a.address_prefix, 0))])
+    error_message = "Each `address_prefix` in `local_peered_address_spaces` must be a valid CIDR block, for example \"10.0.0.0/24\"."
+  }
 }
 
 variable "local_peered_subnets" {
@@ -133,6 +138,11 @@ variable "remote_peered_address_spaces" {
   }))
   default     = []
   description = "The address space of the remote virtual network to peer. Only relevant if peer_complete_vnets is false"
+
+  validation {
+    condition     = alltrue([for a in(var.remote_peered_address_spaces == null ? [] : var.remote_peered_address_spaces) : can(cidrhost(a.address_prefix, 0))])
+    error_message = "Each `address_prefix` in `remote_peered_address_spaces` must be a valid CIDR block, for example \"10.0.0.0/24\"."
+  }
 }
 
 variable "remote_peered_subnets" {
@@ -194,6 +204,11 @@ variable "reverse_local_peered_address_spaces" {
   }))
   default     = []
   description = "The address space of the remote virtual network to peer. Only relevant if reverse_peer_complete_vnets is false"
+
+  validation {
+    condition     = alltrue([for a in(var.reverse_local_peered_address_spaces == null ? [] : var.reverse_local_peered_address_spaces) : can(cidrhost(a.address_prefix, 0))])
+    error_message = "Each `address_prefix` in `reverse_local_peered_address_spaces` must be a valid CIDR block, for example \"10.0.0.0/24\"."
+  }
 }
 
 variable "reverse_local_peered_subnets" {
@@ -232,6 +247,11 @@ variable "reverse_remote_peered_address_spaces" {
   }))
   default     = []
   description = "The address space of the local virtual network to peer. Only relevant if reverse_peer_complete_vnets is false"
+
+  validation {
+    condition     = alltrue([for a in(var.reverse_remote_peered_address_spaces == null ? [] : var.reverse_remote_peered_address_spaces) : can(cidrhost(a.address_prefix, 0))])
+    error_message = "Each `address_prefix` in `reverse_remote_peered_address_spaces` must be a valid CIDR block, for example \"10.0.0.0/24\"."
+  }
 }
 
 variable "reverse_remote_peered_subnets" {

--- a/modules/subnet/tests/unit/cidr_validation.tftest.hcl
+++ b/modules/subnet/tests/unit/cidr_validation.tftest.hcl
@@ -1,0 +1,50 @@
+# Unit tests for the subnet submodule CIDR-format validation on address_prefix
+# and address_prefixes (#136). Runs at plan time with a mocked azapi provider.
+# Execute with: avm test unit
+#
+# Direct submodule consumers must get the same guardrail as root-module callers:
+# a structurally invalid CIDR is rejected at plan time rather than surfacing as
+# an opaque Azure API error at apply.
+
+mock_provider "azapi" {}
+
+variables {
+  name      = "subnet-unit-test"
+  parent_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet"
+}
+
+run "valid_address_prefix_accepted" {
+  command = plan
+
+  variables {
+    address_prefix = "10.0.0.0/24"
+  }
+}
+
+run "valid_address_prefixes_accepted" {
+  command = plan
+
+  variables {
+    address_prefixes = ["10.0.0.0/24", "2001:db8::/64"]
+  }
+}
+
+run "invalid_address_prefix_rejected" {
+  command = plan
+
+  variables {
+    address_prefix = "totally bogus"
+  }
+
+  expect_failures = [var.address_prefix]
+}
+
+run "invalid_address_prefixes_rejected" {
+  command = plan
+
+  variables {
+    address_prefixes = ["10..0.0.0/25"]
+  }
+
+  expect_failures = [var.address_prefixes]
+}

--- a/modules/subnet/variables.tf
+++ b/modules/subnet/variables.tf
@@ -25,6 +25,11 @@ variable "address_prefix" {
   description = <<DESCRIPTION
 (Optional) The address prefix for the subnet. One of `address_prefix`, `address_prefixes`, or `ipam_pools` must be supplied.
 DESCRIPTION
+
+  validation {
+    condition     = var.address_prefix == null ? true : can(cidrhost(var.address_prefix, 0))
+    error_message = "`address_prefix` must be a valid CIDR block, for example \"10.0.0.0/24\"."
+  }
 }
 
 variable "address_prefixes" {
@@ -33,6 +38,11 @@ variable "address_prefixes" {
   description = <<DESCRIPTION
 (Optional) The address prefixes for the subnet. You can supply more than one address prefix. One of `address_prefix`, `address_prefixes`, or `ipam_pools` must be supplied.
 DESCRIPTION
+
+  validation {
+    condition     = var.address_prefixes == null ? true : alltrue([for cidr in var.address_prefixes : can(cidrhost(cidr, 0))])
+    error_message = "Each entry in `address_prefixes` must be a valid CIDR block, for example \"10.0.0.0/24\"."
+  }
 }
 
 variable "default_outbound_access_enabled" {

--- a/tests/unit/cidr_validation.tftest.hcl
+++ b/tests/unit/cidr_validation.tftest.hcl
@@ -1,0 +1,148 @@
+# Unit tests for CIDR-format validation on address_space, subnet address
+# prefixes, and peering peered-address-space inputs (#136, also resolves #133).
+# Runs at plan time with mocked providers - no Azure resources are deployed.
+# Execute with: avm test unit
+#
+# Before this validation, structurally invalid CIDRs (double dots, missing
+# slash, out-of-range prefix length) passed plan and only failed at apply with
+# an opaque Azure API error. Each check uses `can(cidrhost(x, 0))`, which
+# rejects malformed addresses, non-numeric prefixes, and out-of-range prefix
+# lengths for both IPv4 and IPv6.
+
+mock_provider "azapi" {}
+mock_provider "modtm" {}
+mock_provider "random" {}
+
+variables {
+  name             = "vnet-unit-test"
+  location         = "westeurope"
+  parent_id        = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg"
+  enable_telemetry = false
+}
+
+# --- Valid configurations (plan must succeed) ---
+
+run "valid_ipv4_address_space_and_subnets" {
+  command = plan
+
+  variables {
+    address_space = ["10.0.0.0/16"]
+    subnets = {
+      s1 = {
+        name             = "s1"
+        address_prefixes = ["10.0.1.0/24"]
+      }
+      s2 = {
+        name           = "s2"
+        address_prefix = "10.0.2.0/24"
+      }
+    }
+  }
+}
+
+run "valid_ipv6_address_space" {
+  command = plan
+
+  variables {
+    address_space = ["2001:db8::/48"]
+    subnets = {
+      s1 = {
+        name             = "s1"
+        address_prefixes = ["2001:db8:0:1::/64"]
+      }
+    }
+  }
+}
+
+# --- Invalid configurations (validation must fail) ---
+
+# Double dot in an address_space entry.
+run "invalid_address_space_double_dot" {
+  command = plan
+
+  variables {
+    address_space = ["10..0.0.0/25"]
+  }
+
+  expect_failures = [var.address_space]
+}
+
+# A value with no slash / not a CIDR at all.
+run "invalid_address_space_not_a_cidr" {
+  command = plan
+
+  variables {
+    address_space = ["not-a-cidr"]
+  }
+
+  expect_failures = [var.address_space]
+}
+
+# Out-of-range prefix length.
+run "invalid_address_space_prefix_length" {
+  command = plan
+
+  variables {
+    address_space = ["10.0.0.0/99"]
+  }
+
+  expect_failures = [var.address_space]
+}
+
+# Malformed subnet address_prefix (this is the #133 red herring).
+run "invalid_subnet_address_prefix" {
+  command = plan
+
+  variables {
+    address_space = ["10.0.0.0/16"]
+    subnets = {
+      s1 = {
+        name           = "s1"
+        address_prefix = "totally bogus"
+      }
+    }
+  }
+
+  expect_failures = [var.subnets]
+}
+
+# Malformed entry inside subnet address_prefixes.
+run "invalid_subnet_address_prefixes" {
+  command = plan
+
+  variables {
+    address_space = ["10.0.0.0/16"]
+    subnets = {
+      s1 = {
+        name             = "s1"
+        address_prefixes = ["10..0.0.0/25"]
+      }
+    }
+  }
+
+  expect_failures = [var.subnets]
+}
+
+# Malformed peering peered address space.
+run "invalid_peering_address_prefix" {
+  command = plan
+
+  variables {
+    address_space = ["10.0.0.0/16"]
+    peerings = {
+      p1 = {
+        name                               = "peer1"
+        remote_virtual_network_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/remote"
+        peer_complete_vnets                = false
+        local_peered_address_spaces = [{
+          address_prefix = "10..0.0.0/25"
+        }]
+        remote_peered_address_spaces = [{
+          address_prefix = "10.1.0.0/24"
+        }]
+      }
+    }
+  }
+
+  expect_failures = [var.peerings]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -30,6 +30,10 @@ variable "address_space" {
     condition     = (var.address_space != null && var.ipam_pools == null) || (var.address_space == null && var.ipam_pools != null)
     error_message = "Either address_space or ipam_pools must be specified, but not both."
   }
+  validation {
+    condition     = var.address_space == null ? true : alltrue([for cidr in var.address_space : can(cidrhost(cidr, 0))])
+    error_message = "Each entry in address_space must be a valid CIDR block, for example \"10.0.0.0/16\"."
+  }
 }
 
 variable "bgp_community" {
@@ -393,6 +397,18 @@ variable "peerings" {
 
 DESCRIPTION
   nullable    = false
+
+  validation {
+    condition = alltrue([
+      for _, peering in var.peerings : alltrue(concat(
+        [for a in coalesce(peering.local_peered_address_spaces, []) : can(cidrhost(a.address_prefix, 0))],
+        [for a in coalesce(peering.remote_peered_address_spaces, []) : can(cidrhost(a.address_prefix, 0))],
+        [for a in coalesce(peering.reverse_local_peered_address_spaces, []) : can(cidrhost(a.address_prefix, 0))],
+        [for a in coalesce(peering.reverse_remote_peered_address_spaces, []) : can(cidrhost(a.address_prefix, 0))],
+      ))
+    ])
+    error_message = "Each peering `address_prefix` (local/remote/reverse peered address spaces) must be a valid CIDR block, for example \"10.0.0.0/24\"."
+  }
 }
 
 variable "retry" {
@@ -598,6 +614,20 @@ DESCRIPTION
       for _, subnet in var.subnets : subnet.service_endpoints_with_location == null
     ])
     error_message = "`service_endpoints_with_location` has been removed. Use `service_endpoints` with a set of service names instead, for example `service_endpoints = [\"Microsoft.Storage\"]`. Locations are no longer configurable because Azure expands service-endpoint locations implicitly, which caused perpetual drift."
+  }
+  validation {
+    condition = alltrue([
+      for _, subnet in var.subnets :
+      subnet.address_prefix == null ? true : can(cidrhost(subnet.address_prefix, 0))
+    ])
+    error_message = "Each subnet `address_prefix` must be a valid CIDR block, for example \"10.0.0.0/24\"."
+  }
+  validation {
+    condition = alltrue([
+      for _, subnet in var.subnets :
+      subnet.address_prefixes == null ? true : alltrue([for cidr in subnet.address_prefixes : can(cidrhost(cidr, 0))])
+    ])
+    error_message = "Each entry in a subnet's `address_prefixes` must be a valid CIDR block, for example \"10.0.0.0/24\"."
   }
 }
 


### PR DESCRIPTION
## Summary

Adds plan-time CIDR-format validation to every address/prefix input in the module. Structurally invalid values (double dots, missing slash, out-of-range prefix length) currently pass `terraform plan` silently and only fail at apply as an opaque Azure API error. This is purely additive input validation — it rejects configurations that could never have applied successfully, so it does not break any working consumer.

Closes #136. Also resolves #133 (the reported "subnet not created" symptom was actually the invalid CIDR `10..0.0.0/25`, not the `count` guard — see the analysis comment on that issue).

## What changed

Each check uses `can(cidrhost(x, 0))`, which rejects malformed addresses, non-numeric prefixes, and out-of-range prefix lengths for **both IPv4 and IPv6** in a single condition.

**Root module (`variables.tf`)**
- `address_space` — each entry must be a valid CIDR.
- `subnets[*].address_prefix` and `subnets[*].address_prefixes[*]`.
- `peerings[*]` — `local_peered_address_spaces`, `remote_peered_address_spaces`, and the `reverse_*` equivalents.

**Subnet submodule (`modules/subnet/variables.tf`)**
- `address_prefix` and `address_prefixes` (covers direct submodule consumers).

**Peering submodule (`modules/peering/variables.tf`)**
- `local_peered_address_spaces`, `remote_peered_address_spaces`, `reverse_local_peered_address_spaces`, `reverse_remote_peered_address_spaces`.

## Tests

- `tests/unit/cidr_validation.tftest.hcl` — 8 runs: valid IPv4/IPv6 accepted; double-dot, non-CIDR, out-of-range prefix, malformed subnet prefix/prefixes, and malformed peering prefix all rejected.
- `modules/subnet/tests/unit/cidr_validation.tftest.hcl` — 4 runs for the submodule.
- **`avm test unit`: 44 runs, 44 passed.**
- **`avm pre-commit`: pass. `avm pr-check`: all 8 steps pass** (lint 18 scopes, policy, convention, validate, docs).

## Notes

- IPv6 prefixes are handled by the same `cidrhost` condition (explicit IPv6 test cases included).
- No documentation/README churn — variable descriptions were unchanged; the validation is enforced via `validation` blocks only.
